### PR TITLE
fix(api): add .js extensions to relative imports for ESM resolution

### DIFF
--- a/api/booking-rules.ts
+++ b/api/booking-rules.ts
@@ -1,7 +1,7 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
-import { bearerToken, verifyToken } from './_lib/auth';
-import { readBookingRules, writeBookingRules } from './_lib/configStore';
-import { validateBookingRules } from '../src/lib/configValidation';
+import { bearerToken, verifyToken } from './_lib/auth.js';
+import { readBookingRules, writeBookingRules } from './_lib/configStore.js';
+import { validateBookingRules } from '../src/lib/configValidation.js';
 
 async function handleGet(_req: VercelRequest, res: VercelResponse) {
   const doc = await readBookingRules();

--- a/api/config.ts
+++ b/api/config.ts
@@ -3,7 +3,7 @@
 // full MentoringConfig shape the public site (useConfig) expects.
 // Read-only: writes go through /api/topics, /api/mentors, /api/booking-rules.
 import type { VercelRequest, VercelResponse } from '@vercel/node';
-import { readBookingRules, readMentors, readTopics } from './_lib/configStore';
+import { readBookingRules, readMentors, readTopics } from './_lib/configStore.js';
 import type { MentoringConfig } from '../src/types/mentoring';
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {

--- a/api/login.ts
+++ b/api/login.ts
@@ -1,5 +1,5 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
-import { checkPassword, signToken } from './_lib/auth';
+import { checkPassword, signToken } from './_lib/auth.js';
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 

--- a/api/mentors.ts
+++ b/api/mentors.ts
@@ -1,7 +1,7 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
-import { bearerToken, verifyToken } from './_lib/auth';
-import { readMentors, readTopics, writeMentors } from './_lib/configStore';
-import { validateMentors } from '../src/lib/configValidation';
+import { bearerToken, verifyToken } from './_lib/auth.js';
+import { readMentors, readTopics, writeMentors } from './_lib/configStore.js';
+import { validateMentors } from '../src/lib/configValidation.js';
 
 async function handleGet(_req: VercelRequest, res: VercelResponse) {
   const doc = await readMentors();

--- a/api/topics.ts
+++ b/api/topics.ts
@@ -1,7 +1,7 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
-import { bearerToken, verifyToken } from './_lib/auth';
-import { readMentors, readTopics, writeTopics } from './_lib/configStore';
-import { validateTopics } from '../src/lib/configValidation';
+import { bearerToken, verifyToken } from './_lib/auth.js';
+import { readMentors, readTopics, writeTopics } from './_lib/configStore.js';
+import { validateTopics } from '../src/lib/configValidation.js';
 
 async function handleGet(_req: VercelRequest, res: VercelResponse) {
   const doc = await readTopics();


### PR DESCRIPTION
package.json has "type": "module" and Vercel compiles each api/*.ts file standalone, so Node's ESM loader needs explicit extensions on relative imports at runtime. Missing them crashed every serverless function that imported _lib/auth, _lib/configStore, or configValidation with ERR_MODULE_NOT_FOUND (500 on /api/login and /api/config in production).