### PR TITLE
fix(api): add missing .js extension to portfolio types import

### DIFF
--- a/src/lib/portfolioValidation.ts
+++ b/src/lib/portfolioValidation.ts
@@ -7,7 +7,7 @@ import {
   DEFAULT_SECTION_ORDER, PROJECT_PLATFORM_OPTIONS, PROJECT_TYPE_OPTIONS, SKILL_LEVEL_OPTIONS, WORK_ARRANGEMENT_OPTIONS,
   type EmploymentType, type PortfolioData, type PortfolioSectionId, type PortfolioStatus,
   type SkillConfig, type SkillLevel, type ToolConfig, type WorkArrangement,
-} from '../types/portfolio';
+} from '../types/portfolio.js';
 
 const SLUG_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 export const GITHUB_USERNAME_RE = /^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$/;


### PR DESCRIPTION
Node ESM at runtime requires explicit extensions on relative imports. portfolioValidation.ts imported '../types/portfolio' without one, so every serverless function pulling it in (config, portfolios, admin-config, login) crashed with ERR_MODULE_NOT_FOUND in production.