### PR TITLE
QA Library

### DIFF
--- a/api/[...path].ts
+++ b/api/[...path].ts
@@ -10,6 +10,8 @@ import bookingsHandler from './_endpoints/bookings.js';
 import mentorsHandler from './_endpoints/mentors.js';
 import portfoliosHandler from './_endpoints/portfolios.js';
 import adminConfigHandler from './_endpoints/admin-config.js';
+import qaLibraryHandler from './_endpoints/qa-library.js';
+import blobUploadHandler from './_endpoints/blob-upload.js';
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   const segments = req.query.path;
@@ -36,6 +38,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       return mentorsHandler(req, res);
     case 'portfolios':
       return portfoliosHandler(req, res);
+    case 'qa-library':
+      return qaLibraryHandler(req, res);
+    case 'blob-upload':
+      return blobUploadHandler(req, res);
     case 'admin-config': {
       // Map the resource parameter from path for the admin-config sub-handler
       const subPath = req.query.path;

--- a/api/_endpoints/admin-config.ts
+++ b/api/_endpoints/admin-config.ts
@@ -1,11 +1,14 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { resolveAdminSession, resolveSession } from '../_lib/auth.js';
 import {
-  readBookingRules, readSkills, readTools, readTopics, writeBookingRules, writeSkills, writeTools, writeTopics,
+  readBookingRules, readQaLibraryCategories, readSkills, readTools, readTopics,
+  writeBookingRules, writeQaLibraryCategories, writeSkills, writeTools, writeTopics,
 } from '../_lib/configStore.js';
 import { listMentors } from '../_lib/mentorStore.js';
+import { isCategoryInUse } from '../_lib/qaLibraryStore.js';
 import { validateBookingRules, validateTopics } from '../../src/lib/configValidation.js';
 import { validateSkills, validateTools } from '../../src/lib/portfolioValidation.js';
+import { validateQaLibraryCategories } from '../../src/lib/qaLibraryValidation.js';
 
 async function handleTopicsGet(_req: VercelRequest, res: VercelResponse) {
   const doc = await readTopics();
@@ -157,6 +160,58 @@ async function handleBookingRules(req: VercelRequest, res: VercelResponse) {
   return res.status(405).json({ error: 'method_not_allowed' });
 }
 
+async function handleQaLibraryCategoriesGet(_req: VercelRequest, res: VercelResponse) {
+  const doc = await readQaLibraryCategories();
+  res.setHeader('Cache-Control', 'public, max-age=0, s-maxage=60, stale-while-revalidate=300');
+  return res.status(200).json(doc);
+}
+
+async function handleQaLibraryCategoriesPut(req: VercelRequest, res: VercelResponse) {
+  // Admin-only, unlike tools/skills — categories are curated taxonomy for
+  // article organization, not a shared self-serve lookup.
+  if (!(await resolveAdminSession(req, res))) return;
+
+  const result = validateQaLibraryCategories(req.body);
+  if (!result.ok) {
+    return res.status(400).json({ error: 'invalid_categories', errors: result.errors });
+  }
+
+  // Referential integrity: block dropping a category id that a published or
+  // draft article still references (mirrors handleTopicsPut's mentor check).
+  const nextIds = new Set(result.categories.map((c) => c.id));
+  const { categories: currentCategories } = await readQaLibraryCategories();
+  const removedIds = currentCategories.map((c) => c.id).filter((id) => !nextIds.has(id));
+  for (const removedId of removedIds) {
+    if (await isCategoryInUse(removedId)) {
+      return res.status(400).json({
+        error: 'category_in_use',
+        errors: [`Category "${removedId}" masih dipakai oleh artikel. Hapus/ganti kategori artikel itu dulu.`],
+      });
+    }
+  }
+
+  // Optimistic concurrency: client echoes the updatedAt it loaded, applied
+  // atomically as part of the write itself (see writeQaLibraryCategories).
+  const clientVersion = req.headers['x-qa-library-categories-updated-at'];
+  const write = await writeQaLibraryCategories(
+    { categories: result.categories },
+    typeof clientVersion === 'string' ? clientVersion : undefined
+  );
+  if (!write.ok) {
+    return res.status(409).json({ error: 'conflict', current: write.current });
+  }
+
+  res.setHeader('Cache-Control', 'no-store');
+  return res.status(200).json(write.doc);
+}
+
+async function handleQaLibraryCategories(req: VercelRequest, res: VercelResponse) {
+  if (req.method === 'GET') return handleQaLibraryCategoriesGet(req, res);
+  if (req.method === 'PUT') return handleQaLibraryCategoriesPut(req, res);
+  res.setHeader('Allow', 'GET, PUT');
+  return res.status(405).json({ error: 'method_not_allowed' });
+}
+
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   const { resource } = req.query;
 
@@ -164,5 +219,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (resource === 'tools') return handleTools(req, res);
   if (resource === 'skills') return handleSkills(req, res);
   if (resource === 'booking-rules') return handleBookingRules(req, res);
+  if (resource === 'qa-library-categories') return handleQaLibraryCategories(req, res);
   return res.status(404).json({ error: 'not_found' });
 }

--- a/api/_endpoints/blob-upload.ts
+++ b/api/_endpoints/blob-upload.ts
@@ -1,0 +1,58 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { handleUpload, type HandleUploadBody } from '@vercel/blob/client';
+import { resolveAdminSession } from '../_lib/auth.js';
+import { checkRateLimit } from '../_lib/rateLimit.js';
+
+// Client-direct-to-Blob upload token route — the QA Library document field
+// (PDF/PPT, can be tens of MB) uploads straight from the browser to Blob
+// storage instead of through /api/upload's base64-JSON-body path, which is
+// capped at 2MB to stay well under Vercel's ~4.5MB serverless body limit.
+// Admin-only for now, matching the QA Library feature's current scope.
+const ALLOWED_DOC_TYPES = [
+  'application/pdf',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation', // .pptx
+  'application/vnd.ms-powerpoint', // legacy .ppt
+];
+const MAX_DOC_BYTES = 50 * 1024 * 1024;
+const UPLOAD_RATE_LIMIT = { maxAttempts: 20, windowMs: 60 * 60 * 1000 };
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ error: 'method_not_allowed' });
+  }
+
+  const session = await resolveAdminSession(req, res);
+  if (!session) return;
+  if (!process.env.BLOB_READ_WRITE_TOKEN) {
+    return res.status(500).json({ error: 'server_not_configured', message: 'BLOB_READ_WRITE_TOKEN env var is not set.' });
+  }
+
+  const allowed = await checkRateLimit(`blob-upload:${session.userId}`, UPLOAD_RATE_LIMIT.maxAttempts, UPLOAD_RATE_LIMIT.windowMs);
+  if (!allowed) {
+    return res.status(429).json({ error: 'rate_limited', message: 'Terlalu banyak upload. Coba lagi nanti.' });
+  }
+
+  try {
+    const jsonResponse = await handleUpload({
+      body: req.body as HandleUploadBody,
+      request: req,
+      onBeforeGenerateToken: async () => ({
+        allowedContentTypes: ALLOWED_DOC_TYPES,
+        maximumSizeInBytes: MAX_DOC_BYTES,
+        addRandomSuffix: true,
+      }),
+      // No onUploadCompleted: it needs a publicly-reachable callback URL
+      // (doesn't work on localhost), and isn't needed here — the admin form
+      // persists the returned blob.url via the normal authenticated
+      // create/update save, same as any other field.
+    });
+    res.setHeader('Cache-Control', 'no-store');
+    return res.status(200).json(jsonResponse);
+  } catch (err) {
+    return res.status(400).json({
+      error: 'blob_token_failed',
+      message: err instanceof Error ? err.message : 'Gagal membuat token upload.',
+    });
+  }
+}

--- a/api/_endpoints/config.ts
+++ b/api/_endpoints/config.ts
@@ -10,6 +10,7 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { readBookingRules, readTopics } from '../_lib/configStore.js';
 import { listMentors } from '../_lib/mentorStore.js';
 import { listPortfolios } from '../_lib/portfolioStore.js';
+import { listQaLibraryArticles } from '../_lib/qaLibraryStore.js';
 import type { MentoringConfig } from '../../src/types/mentoring';
 
 const SITE_URL = 'https://www.mentorqa.com';
@@ -29,6 +30,7 @@ const STATIC_ROUTES: UrlEntry[] = [
   { loc: '/personal-portfolio/about', changefreq: 'monthly', priority: '0.6' },
   { loc: '/personal-portfolio/projects', changefreq: 'monthly', priority: '0.7' },
   { loc: '/personal-portfolio/certifications', changefreq: 'monthly', priority: '0.5' },
+  { loc: '/qa-library', changefreq: 'weekly', priority: '0.8' },
 ];
 
 function toXml(entries: UrlEntry[]): string {
@@ -42,9 +44,10 @@ function toXml(entries: UrlEntry[]): string {
 }
 
 async function handleSitemap(res: VercelResponse) {
-  const [mentors, portfolios] = await Promise.all([
+  const [mentors, portfolios, qaLibraryArticles] = await Promise.all([
     listMentors({ verifiedOnly: true }),
     listPortfolios(),
+    listQaLibraryArticles({ publishedOnly: true }),
   ]);
 
   const mentorEntries: UrlEntry[] = mentors.map((m) => ({
@@ -63,7 +66,14 @@ async function handleSitemap(res: VercelResponse) {
       lastmod: p.updatedAt,
     }));
 
-  const xml = toXml([...STATIC_ROUTES, ...mentorEntries, ...portfolioEntries]);
+  const qaLibraryEntries: UrlEntry[] = qaLibraryArticles.map((a) => ({
+    loc: `/qa-library/${a.slug}`,
+    changefreq: 'monthly',
+    priority: '0.6',
+    lastmod: a.updatedAt,
+  }));
+
+  const xml = toXml([...STATIC_ROUTES, ...mentorEntries, ...portfolioEntries, ...qaLibraryEntries]);
 
   res.setHeader('Content-Type', 'application/xml; charset=utf-8');
   res.setHeader('Cache-Control', 'public, max-age=0, s-maxage=3600, stale-while-revalidate=86400');

--- a/api/_endpoints/qa-library.ts
+++ b/api/_endpoints/qa-library.ts
@@ -1,0 +1,163 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { requireSession, resolveAdminSession } from '../_lib/auth.js';
+import { readQaLibraryCategories } from '../_lib/configStore.js';
+import {
+  createQaLibraryArticle, deleteQaLibraryArticle, incrementQaLibraryArticleViewCount, isSlugTaken,
+  listQaLibraryArticles, readQaLibraryArticleBySlug, updateQaLibraryArticle,
+} from '../_lib/qaLibraryStore.js';
+import { computeReadingTimeMinutes, validateQaLibraryArticleData } from '../../src/lib/qaLibraryValidation.js';
+import { isValidSlug, slugify } from '../../src/lib/portfolioValidation.js';
+
+// Admin-only list — every status, no auth-visibility split needed since the
+// whole response is gated. Mirrors handleAdminList precedent (bookings.ts).
+async function handleAdminList(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).json({ error: 'method_not_allowed' });
+  }
+  if (!(await resolveAdminSession(req, res))) return;
+
+  const articles = await listQaLibraryArticles();
+  res.setHeader('Cache-Control', 'no-store');
+  return res.status(200).json({ articles });
+}
+
+// Public list — published only, optional category filter. Unlike
+// bookings.ts/portfolios.ts (which have no root handler at all, a known
+// dead-code gap — see turso.ts/mentors.ts comments), this explicitly
+// implements GET/POST at the root so /api/qa-library actually works.
+async function handleRootGet(req: VercelRequest, res: VercelResponse) {
+  const { category } = req.query;
+  const categoryId = typeof category === 'string' && category ? category : undefined;
+  const articles = await listQaLibraryArticles({ publishedOnly: true, categoryId });
+  res.setHeader('Cache-Control', 'public, max-age=0, s-maxage=60, stale-while-revalidate=300');
+  return res.status(200).json({ articles });
+}
+
+async function handleRootPost(req: VercelRequest, res: VercelResponse) {
+  if (!(await resolveAdminSession(req, res))) return;
+
+  const body = typeof req.body === 'object' && req.body !== null ? (req.body as Record<string, unknown>) : {};
+  const title = typeof body.title === 'string' ? body.title : '';
+  const requestedSlug = typeof body.slug === 'string' && body.slug ? body.slug : slugify(title);
+
+  if (!isValidSlug(requestedSlug)) {
+    return res.status(400).json({ error: 'invalid_slug', errors: ['slug: harus slug lowercase (a-z, 0-9, tanda hubung).'] });
+  }
+  if (await isSlugTaken(requestedSlug)) {
+    return res.status(409).json({ error: 'slug_taken', errors: [`slug "${requestedSlug}" sudah dipakai.`] });
+  }
+
+  const { categories } = await readQaLibraryCategories();
+  const validCategoryIds = new Set(categories.map((c) => c.id));
+  const result = validateQaLibraryArticleData(body, validCategoryIds);
+  if (!result.ok) {
+    return res.status(400).json({ error: 'invalid_article', errors: result.errors });
+  }
+
+  const readingTimeMinutes = computeReadingTimeMinutes(result.article.body);
+  const article = await createQaLibraryArticle(requestedSlug, result.article, readingTimeMinutes);
+  res.setHeader('Cache-Control', 'no-store');
+  return res.status(201).json(article);
+}
+
+async function handleRoot(req: VercelRequest, res: VercelResponse) {
+  if (req.method === 'GET') return handleRootGet(req, res);
+  if (req.method === 'POST') return handleRootPost(req, res);
+  res.setHeader('Allow', 'GET, POST');
+  return res.status(405).json({ error: 'method_not_allowed' });
+}
+
+// Public reader — drafts are only visible to an admin session, mirroring
+// portfolios.ts handleSlugGet's canSeeDraft pattern. Never varies s-maxage by
+// session (a shared edge cache doesn't check Authorization).
+async function handleSlugGet(req: VercelRequest, res: VercelResponse, slug: string) {
+  let article = await readQaLibraryArticleBySlug(slug);
+  if (!article) return res.status(404).json({ error: 'not_found' });
+
+  const sessionSecret = process.env.SESSION_SECRET;
+  const session = sessionSecret ? await requireSession(sessionSecret, req.headers.authorization) : null;
+  const canSeeDraft = Boolean(session?.roles.includes('admin'));
+
+  if (article.status === 'published' || canSeeDraft) {
+    // Only count genuine anonymous public reads — the admin form's edit/preview
+    // load always sends an Authorization header, so an authenticated request
+    // (any role, not just admin) never bumps the counter.
+    if (article.status === 'published' && !session) {
+      const viewCount = await incrementQaLibraryArticleViewCount(article.id);
+      article = { ...article, viewCount };
+    }
+    res.setHeader('Cache-Control', canSeeDraft ? 'no-store' : 'public, max-age=0, s-maxage=60, stale-while-revalidate=300');
+    return res.status(200).json(article);
+  }
+
+  return res.status(404).json({ error: 'not_found' });
+}
+
+async function handleSlugPut(req: VercelRequest, res: VercelResponse, currentSlug: string) {
+  if (!(await resolveAdminSession(req, res))) return;
+
+  const existing = await readQaLibraryArticleBySlug(currentSlug);
+  if (!existing) return res.status(404).json({ error: 'not_found' });
+
+  const body = typeof req.body === 'object' && req.body !== null ? (req.body as Record<string, unknown>) : {};
+  const nextSlug = typeof body.slug === 'string' && body.slug ? body.slug : currentSlug;
+
+  if (!isValidSlug(nextSlug)) {
+    return res.status(400).json({ error: 'invalid_slug', errors: ['slug: harus slug lowercase (a-z, 0-9, tanda hubung).'] });
+  }
+  if (nextSlug !== existing.slug && (await isSlugTaken(nextSlug, existing.id))) {
+    return res.status(409).json({ error: 'slug_taken', errors: [`slug "${nextSlug}" sudah dipakai.`] });
+  }
+
+  const { categories } = await readQaLibraryCategories();
+  const validCategoryIds = new Set(categories.map((c) => c.id));
+  const result = validateQaLibraryArticleData(body, validCategoryIds);
+  if (!result.ok) {
+    return res.status(400).json({ error: 'invalid_article', errors: result.errors });
+  }
+
+  const readingTimeMinutes = computeReadingTimeMinutes(result.article.body);
+
+  // Optimistic concurrency: client echoes the updatedAt it loaded.
+  const clientVersion = req.headers['x-qa-library-article-updated-at'];
+  const expectedUpdatedAt = typeof clientVersion === 'string' ? clientVersion : existing.updatedAt;
+
+  const write = await updateQaLibraryArticle(existing.id, nextSlug, result.article, readingTimeMinutes, expectedUpdatedAt);
+  if (!write.ok) {
+    if (write.reason === 'not_found') return res.status(404).json({ error: 'not_found' });
+    return res.status(409).json({ error: 'conflict', current: write.current });
+  }
+
+  res.setHeader('Cache-Control', 'no-store');
+  return res.status(200).json(write.article);
+}
+
+async function handleSlugDelete(req: VercelRequest, res: VercelResponse, slug: string) {
+  if (!(await resolveAdminSession(req, res))) return;
+
+  const existing = await readQaLibraryArticleBySlug(slug);
+  if (!existing) return res.status(404).json({ error: 'not_found' });
+
+  await deleteQaLibraryArticle(existing.id);
+  res.setHeader('Cache-Control', 'no-store');
+  return res.status(204).end();
+}
+
+async function handleSlug(req: VercelRequest, res: VercelResponse, slug: string) {
+  if (req.method === 'GET') return handleSlugGet(req, res, slug);
+  if (req.method === 'PUT') return handleSlugPut(req, res, slug);
+  if (req.method === 'DELETE') return handleSlugDelete(req, res, slug);
+  res.setHeader('Allow', 'GET, PUT, DELETE');
+  return res.status(405).json({ error: 'method_not_allowed' });
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  const segments = req.query.path;
+  const path = Array.isArray(segments) ? segments : typeof segments === 'string' ? [segments] : [];
+  const [first] = path;
+
+  if (first === 'admin') return handleAdminList(req, res);
+  if (first) return handleSlug(req, res, first);
+  return handleRoot(req, res);
+}

--- a/api/_endpoints/upload.ts
+++ b/api/_endpoints/upload.ts
@@ -25,6 +25,7 @@ const FOLDER_BY_FEATURE = {
   portfolio: 'Portfolio',
   cv: 'CV',
   tools: 'Tools',
+  qaLibrary: 'QaLibrary',
 } as const;
 type UploadFeature = keyof typeof FOLDER_BY_FEATURE;
 

--- a/api/_lib/configStore.ts
+++ b/api/_lib/configStore.ts
@@ -6,6 +6,7 @@
 // row-level concurrency, not whole-document CAS.
 import type { BookingRulesDocument, MentoringConfig, TopicConfig, TopicsDocument } from '../../src/types/mentoring';
 import type { SkillConfig, SkillsDocument, ToolConfig, ToolsDocument } from '../../src/types/portfolio';
+import type { QaLibraryCategoriesDocument, QaLibraryCategory } from '../../src/types/qaLibrary';
 // Bundled into the function at build time — the pre-seed fallback and the
 // permanent degradation path if a resource hasn't been written to Turso yet.
 import staticConfig from '../../public/mentoring/config/qa-mentoring-config.json' with { type: 'json' };
@@ -122,5 +123,23 @@ export async function writeSkills(
   const result = await casWriteDocument('skills', doc.skills, expectedUpdatedAt);
   if (!result.ok) return { ok: false, current: await readSkills() };
   return { ok: true, doc: { skills: doc.skills, updatedAt: result.updatedAt } };
+}
+
+// QA Library categories is a small admin-curated taxonomy, same document-per-key
+// shape as topics/tools/skills. No static seed — new resource, starts empty
+// until the admin adds categories.
+export async function readQaLibraryCategories(): Promise<QaLibraryCategoriesDocument> {
+  const doc = await readDocument<QaLibraryCategory[]>('qa-library-categories');
+  if (doc) return { categories: doc.data, updatedAt: doc.updatedAt };
+  return { categories: [] };
+}
+
+export async function writeQaLibraryCategories(
+  doc: Pick<QaLibraryCategoriesDocument, 'categories'>,
+  expectedUpdatedAt: string | undefined
+): Promise<WriteResult<QaLibraryCategoriesDocument>> {
+  const result = await casWriteDocument('qa-library-categories', doc.categories, expectedUpdatedAt);
+  if (!result.ok) return { ok: false, current: await readQaLibraryCategories() };
+  return { ok: true, doc: { categories: doc.categories, updatedAt: result.updatedAt } };
 }
 

--- a/api/_lib/qaLibraryStore.ts
+++ b/api/_lib/qaLibraryStore.ts
@@ -1,0 +1,196 @@
+// Read/write QA Library article records in Turso. Real per-row table (mirrors
+// bookingStore.ts/portfolioStore.ts's per-row CAS pattern) — articles are
+// discrete, independently-edited records expected to grow over time, unlike
+// the small whole-doc categories resource (see configStore.ts).
+import type { Row } from '@libsql/client';
+import type { QaLibraryArticle, QaLibraryArticleData, QaLibraryArticleSummary } from '../../src/types/qaLibrary';
+import { getClient, migrate } from './turso.js';
+
+export type QaLibraryWriteResult =
+  | { ok: true; article: QaLibraryArticle }
+  | { ok: false; reason: 'conflict'; current: QaLibraryArticle | null }
+  | { ok: false; reason: 'not_found' };
+
+function rowToArticle(row: Row): QaLibraryArticle {
+  return {
+    id: row.id as string,
+    slug: row.slug as string,
+    title: row.title as string,
+    categoryId: row.category_id as string,
+    excerpt: row.excerpt as string,
+    body: row.body as string,
+    thumbnailUrl: (row.thumbnail_url as string | null) ?? undefined,
+    docUrl: (row.doc_url as string | null) ?? undefined,
+    docFilename: (row.doc_filename as string | null) ?? undefined,
+    docSizeBytes: (row.doc_size_bytes as number | null) ?? undefined,
+    tags: JSON.parse(row.tags as string) as string[],
+    authorName: row.author_name as string,
+    authorUserId: (row.author_user_id as string | null) ?? undefined,
+    authorAvatarUrl: (row.author_avatar_url as string | null) ?? undefined,
+    readingTimeMinutes: row.reading_time_minutes as number,
+    viewCount: row.view_count as number,
+    status: row.status as QaLibraryArticle['status'],
+    seoMetaTitle: (row.seo_meta_title as string | null) ?? undefined,
+    seoMetaDescription: (row.seo_meta_description as string | null) ?? undefined,
+    seoOgImage: (row.seo_og_image as string | null) ?? undefined,
+    createdAt: row.created_at as string,
+    updatedAt: row.updated_at as string,
+  };
+}
+
+function rowToSummary(row: Row): QaLibraryArticleSummary {
+  return {
+    id: row.id as string,
+    slug: row.slug as string,
+    title: row.title as string,
+    categoryId: row.category_id as string,
+    excerpt: row.excerpt as string,
+    thumbnailUrl: (row.thumbnail_url as string | null) ?? undefined,
+    tags: JSON.parse(row.tags as string) as string[],
+    status: row.status as QaLibraryArticleSummary['status'],
+    readingTimeMinutes: row.reading_time_minutes as number,
+    authorName: row.author_name as string,
+    authorAvatarUrl: (row.author_avatar_url as string | null) ?? undefined,
+    updatedAt: row.updated_at as string,
+  };
+}
+
+export async function listQaLibraryArticles(opts?: { publishedOnly?: boolean; categoryId?: string }): Promise<QaLibraryArticleSummary[]> {
+  await migrate();
+  const db = getClient();
+  const conditions: string[] = [];
+  const args: string[] = [];
+  if (opts?.publishedOnly) conditions.push(`status = 'published'`);
+  if (opts?.categoryId) { conditions.push('category_id = ?'); args.push(opts.categoryId); }
+  const where = conditions.length > 0 ? ` WHERE ${conditions.join(' AND ')}` : '';
+  const result = await db.execute({
+    sql: `SELECT id, slug, title, category_id, excerpt, thumbnail_url, tags, status, reading_time_minutes,
+                 author_name, author_avatar_url, updated_at
+          FROM qa_library_articles${where} ORDER BY updated_at DESC`,
+    args,
+  });
+  return result.rows.map(rowToSummary);
+}
+
+export async function readQaLibraryArticleBySlug(slug: string): Promise<QaLibraryArticle | null> {
+  await migrate();
+  const db = getClient();
+  const result = await db.execute({ sql: 'SELECT * FROM qa_library_articles WHERE slug = ?', args: [slug] });
+  const row = result.rows[0];
+  return row ? rowToArticle(row) : null;
+}
+
+export async function readQaLibraryArticleById(id: string): Promise<QaLibraryArticle | null> {
+  await migrate();
+  const db = getClient();
+  const result = await db.execute({ sql: 'SELECT * FROM qa_library_articles WHERE id = ?', args: [id] });
+  const row = result.rows[0];
+  return row ? rowToArticle(row) : null;
+}
+
+export async function isSlugTaken(slug: string, excludeId?: string): Promise<boolean> {
+  await migrate();
+  const db = getClient();
+  const result = await db.execute({
+    sql: excludeId ? 'SELECT 1 FROM qa_library_articles WHERE slug = ? AND id != ?' : 'SELECT 1 FROM qa_library_articles WHERE slug = ?',
+    args: excludeId ? [slug, excludeId] : [slug],
+  });
+  return result.rows.length > 0;
+}
+
+export async function isCategoryInUse(categoryId: string): Promise<boolean> {
+  await migrate();
+  const db = getClient();
+  const result = await db.execute({ sql: 'SELECT 1 FROM qa_library_articles WHERE category_id = ?', args: [categoryId] });
+  return result.rows.length > 0;
+}
+
+export async function createQaLibraryArticle(
+  slug: string,
+  data: QaLibraryArticleData,
+  readingTimeMinutes: number
+): Promise<QaLibraryArticle> {
+  await migrate();
+  const db = getClient();
+  const now = new Date().toISOString();
+  const id = crypto.randomUUID();
+  await db.execute({
+    sql: `INSERT INTO qa_library_articles
+            (id, slug, title, category_id, excerpt, body, thumbnail_url, doc_url, doc_filename, doc_size_bytes,
+             tags, author_name, author_user_id, author_avatar_url, reading_time_minutes, status,
+             seo_meta_title, seo_meta_description, seo_og_image, created_at, updated_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    args: [
+      id, slug, data.title, data.categoryId, data.excerpt, data.body,
+      data.thumbnailUrl ?? null, data.docUrl ?? null, data.docFilename ?? null, data.docSizeBytes ?? null,
+      JSON.stringify(data.tags), data.authorName, data.authorUserId ?? null, data.authorAvatarUrl ?? null,
+      readingTimeMinutes, data.status,
+      data.seoMetaTitle ?? null, data.seoMetaDescription ?? null, data.seoOgImage ?? null,
+      now, now,
+    ],
+  });
+  return { id, slug, ...data, readingTimeMinutes, viewCount: 0, createdAt: now, updatedAt: now };
+}
+
+// Per-row CAS, mirrors updatePortfolio/updateBooking.
+export async function updateQaLibraryArticle(
+  id: string,
+  slug: string,
+  data: QaLibraryArticleData,
+  readingTimeMinutes: number,
+  expectedUpdatedAt: string
+): Promise<QaLibraryWriteResult> {
+  await migrate();
+  const db = getClient();
+  const updatedAt = new Date().toISOString();
+  const result = await db.execute({
+    sql: `UPDATE qa_library_articles SET
+            slug = ?, title = ?, category_id = ?, excerpt = ?, body = ?, thumbnail_url = ?, doc_url = ?,
+            doc_filename = ?, doc_size_bytes = ?, tags = ?, author_name = ?, author_user_id = ?, author_avatar_url = ?,
+            reading_time_minutes = ?, status = ?, seo_meta_title = ?, seo_meta_description = ?, seo_og_image = ?,
+            updated_at = ?
+          WHERE id = ? AND updated_at IS ?
+          RETURNING created_at, view_count`,
+    args: [
+      slug, data.title, data.categoryId, data.excerpt, data.body, data.thumbnailUrl ?? null, data.docUrl ?? null,
+      data.docFilename ?? null, data.docSizeBytes ?? null, JSON.stringify(data.tags), data.authorName,
+      data.authorUserId ?? null, data.authorAvatarUrl ?? null,
+      readingTimeMinutes, data.status, data.seoMetaTitle ?? null, data.seoMetaDescription ?? null,
+      data.seoOgImage ?? null, updatedAt,
+      id, expectedUpdatedAt,
+    ],
+  });
+  const row = result.rows[0];
+  if (!row) {
+    const current = await readQaLibraryArticleById(id);
+    if (!current) return { ok: false, reason: 'not_found' };
+    return { ok: false, reason: 'conflict', current };
+  }
+  return {
+    ok: true,
+    article: {
+      id, slug, ...data, readingTimeMinutes, viewCount: row.view_count as number,
+      createdAt: row.created_at as string, updatedAt,
+    },
+  };
+}
+
+export async function deleteQaLibraryArticle(id: string): Promise<void> {
+  await migrate();
+  const db = getClient();
+  await db.execute({ sql: 'DELETE FROM qa_library_articles WHERE id = ?', args: [id] });
+}
+
+// Fire-and-forget-friendly: called from the public GET route on every
+// anonymous view. Not exact under heavy concurrency (no row lock beyond the
+// atomic `+1` UPDATE itself), same trade-off already accepted by
+// rateLimit.ts's counter — fine for a display metric, not a billing figure.
+export async function incrementQaLibraryArticleViewCount(id: string): Promise<number> {
+  await migrate();
+  const db = getClient();
+  const result = await db.execute({
+    sql: 'UPDATE qa_library_articles SET view_count = view_count + 1 WHERE id = ? RETURNING view_count',
+    args: [id],
+  });
+  return (result.rows[0]?.view_count as number | undefined) ?? 0;
+}

--- a/api/_lib/turso.ts
+++ b/api/_lib/turso.ts
@@ -98,6 +98,28 @@ async function runMigrate(): Promise<void> {
         created_at TEXT NOT NULL,
         updated_at TEXT NOT NULL
       )`,
+      `CREATE TABLE IF NOT EXISTS qa_library_articles (
+        id TEXT PRIMARY KEY,
+        slug TEXT NOT NULL UNIQUE,
+        title TEXT NOT NULL,
+        category_id TEXT NOT NULL,
+        excerpt TEXT NOT NULL,
+        body TEXT NOT NULL,
+        thumbnail_url TEXT,
+        doc_url TEXT,
+        doc_filename TEXT,
+        doc_size_bytes INTEGER,
+        tags TEXT NOT NULL DEFAULT '[]',
+        author_name TEXT NOT NULL DEFAULT 'Mentor.QA Team',
+        reading_time_minutes INTEGER NOT NULL DEFAULT 1,
+        status TEXT NOT NULL DEFAULT 'draft',
+        seo_meta_title TEXT,
+        seo_meta_description TEXT,
+        seo_og_image TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      )`,
+      `CREATE INDEX IF NOT EXISTS qa_library_articles_status_category ON qa_library_articles(status, category_id)`,
     ],
     'write'
   );
@@ -105,6 +127,9 @@ async function runMigrate(): Promise<void> {
   await ensureColumn(db, 'portfolios', 'owner_id', 'TEXT');
   await db.execute('CREATE UNIQUE INDEX IF NOT EXISTS portfolios_owner_id_unique ON portfolios(owner_id)');
   await ensureColumn(db, 'bookings', 'mentee_user_id', 'TEXT');
+  await ensureColumn(db, 'qa_library_articles', 'author_user_id', 'TEXT');
+  await ensureColumn(db, 'qa_library_articles', 'author_avatar_url', 'TEXT');
+  await ensureColumn(db, 'qa_library_articles', 'view_count', 'INTEGER NOT NULL DEFAULT 0');
 
   await carryOverLegacyMentors(db);
 }

--- a/api/qa-library-og.ts
+++ b/api/qa-library-og.ts
@@ -1,0 +1,93 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { readQaLibraryArticleBySlug } from './_lib/qaLibraryStore.js';
+
+// Bot-only HTML shell for /qa-library/:slug — vercel.json rewrites requests
+// whose User-Agent matches a known crawler (social preview bots + search
+// engines) here before they'd hit the SPA's static index.html. Non-JS
+// crawlers never run react-helmet-async, so without this they'd see the
+// generic site-wide OG tags baked into index.html instead of the article's
+// own title/description/thumbnail. Real browsers never match the rewrite
+// and get the normal React app.
+const SITE_URL = 'https://www.mentorqa.com';
+const DEFAULT_OG_IMAGE = `${SITE_URL}/shared/img/DEFAULT_OG_IMAGE.png`;
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function notFoundHtml(): string {
+  return '<!doctype html><html lang="id"><head><meta charset="UTF-8" /><meta name="robots" content="noindex, nofollow" /><title>Artikel tidak ditemukan | QA Library</title></head><body>Artikel tidak ditemukan.</body></html>';
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  const slugParam = req.query.slug;
+  const slug = typeof slugParam === 'string' ? slugParam : Array.isArray(slugParam) ? slugParam[0] : '';
+  const article = slug ? await readQaLibraryArticleBySlug(slug) : null;
+
+  if (!article || article.status !== 'published') {
+    res.setHeader('Content-Type', 'text/html; charset=utf-8');
+    res.setHeader('Cache-Control', 'no-store');
+    return res.status(404).send(notFoundHtml());
+  }
+
+  const url = `${SITE_URL}/qa-library/${article.slug}`;
+  const title = escapeHtml(article.seoMetaTitle || `${article.title} | QA Library`);
+  const description = escapeHtml(article.seoMetaDescription || article.excerpt);
+  const image = escapeHtml(article.seoOgImage || article.thumbnailUrl || DEFAULT_OG_IMAGE);
+  const bodyHtml = renderToStaticMarkup(React.createElement(ReactMarkdown, { remarkPlugins: [remarkGfm] }, article.body));
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: article.title,
+    description: article.excerpt,
+    image: article.thumbnailUrl ? [article.thumbnailUrl] : undefined,
+    datePublished: article.createdAt,
+    dateModified: article.updatedAt,
+    author: { '@type': 'Person', name: article.authorName },
+    mainEntityOfPage: { '@type': 'WebPage', '@id': url },
+  };
+
+  const html = `<!doctype html>
+<html lang="id">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>${title}</title>
+<meta name="description" content="${description}" />
+<link rel="canonical" href="${url}" />
+<meta property="og:type" content="article" />
+<meta property="og:site_name" content="Mentor.QA | QA Engineer" />
+<meta property="og:title" content="${title}" />
+<meta property="og:description" content="${description}" />
+<meta property="og:url" content="${url}" />
+<meta property="og:image" content="${image}" />
+<meta property="og:locale" content="id_ID" />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="${title}" />
+<meta name="twitter:description" content="${description}" />
+<meta name="twitter:image" content="${image}" />
+<script type="application/ld+json">${JSON.stringify(jsonLd).replace(/</g, '\\u003c')}</script>
+</head>
+<body>
+<article>
+<h1>${escapeHtml(article.title)}</h1>
+<p>${description}</p>
+${bodyHtml}
+</article>
+</body>
+</html>`;
+
+  res.setHeader('Content-Type', 'text/html; charset=utf-8');
+  res.setHeader('Cache-Control', 'public, max-age=0, s-maxage=300, stale-while-revalidate=3600');
+  return res.status(200).send(html);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "react-helmet-async": "^3.0.0",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^7.13.0",
+        "remark-gfm": "^4.0.1",
         "zustand": "^5.0.14"
       },
       "devDependencies": {
@@ -5301,6 +5302,44 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/mdast-util-from-markdown": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
@@ -5319,6 +5358,107 @@
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0",
         "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -5537,6 +5677,127 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-factory-destination": {
@@ -6623,6 +6884,24 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-parse": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
@@ -6650,6 +6929,21 @@
         "mdast-util-to-hast": "^13.0.0",
         "unified": "^11.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react-helmet-async": "^3.0.0",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.13.0",
+    "remark-gfm": "^4.0.1",
     "zustand": "^5.0.14"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,8 @@ const PortfolioBookingPage = lazy(() => import('./features/mentoring/pages/Booki
 const MentorDetailPage = lazy(() => import('./features/mentoring/pages/MentorDetailPage'));
 const PortfolioLandingPage = lazy(() => import('./features/saas-portfolio/pages/PortfolioLandingPage'));
 const PublicPortfolioPage = lazy(() => import('./features/saas-portfolio/pages/PublicPortfolioPage'));
+const QaLibraryIndexPage = lazy(() => import('./features/qa-library/pages/QaLibraryIndexPage'));
+const QaLibraryArticleDetailPage = lazy(() => import('./features/qa-library/pages/QaLibraryArticleDetailPage'));
 const AdminPage = lazy(() => import('./features/admin/pages/AdminPage'));
 const LoginScreen = lazy(() => import('./features/admin/components/shared/LoginScreen'));
 const Snackbar = lazy(() => import('./features/admin/components/shared/Snackbar').then((m) => ({ default: m.Snackbar })));
@@ -238,6 +240,27 @@ function App() {
           element={
             <LightdashLayout>
               <MentorDetailPage />
+            </LightdashLayout>
+          }
+        />
+        <Route
+          path="/qa-library"
+          element={
+            <LightdashLayout>
+              <Seo
+                path="/qa-library"
+                title="QA Library - Artikel & Materi QA Engineer | Mentor.QA"
+                description="Kumpulan artikel dan materi seputar manual testing, automation testing, dan API testing untuk QA Engineer."
+              />
+              <QaLibraryIndexPage />
+            </LightdashLayout>
+          }
+        />
+        <Route
+          path="/qa-library/:slug"
+          element={
+            <LightdashLayout>
+              <QaLibraryArticleDetailPage />
             </LightdashLayout>
           }
         />

--- a/src/features/admin/components/shared/AdminDashboard.tsx
+++ b/src/features/admin/components/shared/AdminDashboard.tsx
@@ -3,7 +3,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import {
   RefreshCw,
   Users, BookOpen, SlidersHorizontal, CalendarCheck, Menu, X,
-  UserSquare2, Wrench, LayoutDashboard, UserCog, Sparkles,
+  UserSquare2, Wrench, LayoutDashboard, UserCog, Sparkles, Newspaper, Tag,
   type LucideIcon,
 } from 'lucide-react';
 import { useAdminAuthStore } from '../../../../store/useAdminAuthStore';
@@ -12,6 +12,7 @@ import { useAdminMentorStore } from '../../../../store/useAdminMentorStore';
 import { useAdminBookingsStore } from '../../../../store/useAdminBookingsStore';
 import { useAdminPortfolioStore } from '../../../../store/useAdminPortfolioStore';
 import { useAdminUsersStore } from '../../../../store/useAdminUsersStore';
+import { useAdminQaLibraryCategoriesStore } from '../../../../store/useAdminQaLibraryCategoriesStore';
 import LoadingState from '../../../../components/common/LoadingState';
 import AdminHomeTab from '../superadmin/AdminHomeTab';
 import BookingRulesTab from '../superadmin/BookingRulesTab';
@@ -22,9 +23,13 @@ import PortfoliosTab from '../superadmin/PortfoliosTab';
 import ToolsTab from '../superadmin/ToolsTab';
 import SkillsTab from '../superadmin/SkillsTab';
 import UsersTab from '../superadmin/UsersTab';
+import QaLibraryTab from '../superadmin/QaLibraryTab';
+import QaLibraryCategoriesTab from '../superadmin/QaLibraryCategoriesTab';
 import ProfileMenu from './ProfileMenu';
 
-type NavId = 'home' | 'bookings' | 'mentors' | 'users' | 'topics' | 'rules' | 'portfolios' | 'tools' | 'skills';
+type NavId =
+  | 'home' | 'bookings' | 'mentors' | 'users' | 'topics' | 'rules' | 'portfolios' | 'tools' | 'skills'
+  | 'qa-library' | 'qa-library-categories';
 
 interface NavItem {
   id: NavId;
@@ -70,6 +75,14 @@ const NAV_GROUPS: NavGroup[] = [
     ],
   },
   {
+    id: 'content',
+    label: 'Content',
+    items: [
+      { id: 'qa-library', label: 'Articles', description: 'Artikel & materi QA library', icon: Newspaper },
+      { id: 'qa-library-categories', label: 'Article Categories', description: 'Kategori artikel QA library', icon: Tag },
+    ],
+  },
+  {
     id: 'master-data',
     label: 'Master Data',
     items: [
@@ -94,11 +107,15 @@ const AdminDashboard: React.FC = () => {
   const loadBookings = useAdminBookingsStore((s) => s.load);
   const loadPortfolios = useAdminPortfolioStore((s) => s.load);
   const loadUsers = useAdminUsersStore((s) => s.load);
+  const loadQaLibraryCategories = useAdminQaLibraryCategoriesStore((s) => s.load);
   const location = useLocation();
   const navigate = useNavigate();
   const activeNav: NavId = (() => {
     const seg = location.pathname.replace(/^\/dashboard\/?/, '').split('/')[0];
-    const validIds: NavId[] = ['bookings', 'mentors', 'users', 'topics', 'rules', 'portfolios', 'tools', 'skills'];
+    const validIds: NavId[] = [
+      'bookings', 'mentors', 'users', 'topics', 'rules', 'portfolios', 'tools', 'skills',
+      'qa-library', 'qa-library-categories',
+    ];
     return (validIds as string[]).includes(seg) ? (seg as NavId) : 'home';
   })();
   const navPath = (id: NavId) => (id === 'home' ? '/dashboard' : `/dashboard/${id}`);
@@ -115,7 +132,8 @@ const AdminDashboard: React.FC = () => {
     loadBookings();
     loadPortfolios();
     loadUsers();
-  }, [load, loadMentors, loadBookings, loadPortfolios, loadUsers]);
+    loadQaLibraryCategories();
+  }, [load, loadMentors, loadBookings, loadPortfolios, loadUsers, loadQaLibraryCategories]);
 
   if (loading) {
     return <LoadingState label="Memuat config…" className="min-h-screen" />;
@@ -240,6 +258,8 @@ const AdminDashboard: React.FC = () => {
           {activeNav === 'portfolios' && <PortfoliosTab />}
           {activeNav === 'tools' && <ToolsTab />}
           {activeNav === 'skills' && <SkillsTab />}
+          {activeNav === 'qa-library' && <QaLibraryTab />}
+          {activeNav === 'qa-library-categories' && <QaLibraryCategoriesTab />}
         </main>
       </div>
     </div>

--- a/src/features/admin/components/shared/LightdashNavbar.tsx
+++ b/src/features/admin/components/shared/LightdashNavbar.tsx
@@ -11,6 +11,7 @@ const navLinks = [
 ];
 
 const portfolioLink = { label: 'Portfolio QA', to: '/portfolio' };
+const qaLibraryLink = { label: 'QA Library', to: '/qa-library' };
 
 const LightdashNavbar: React.FC = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -49,6 +50,12 @@ const LightdashNavbar: React.FC = () => {
               <span className="inline-flex items-center px-1.5 py-1 rounded-sm bg-ld-violet text-white text-[10px] font-semibold leading-none tracking-wide">
                 New
               </span>
+            </Link>
+            <Link
+              to={qaLibraryLink.to}
+              className="text-sm font-medium text-ld-graphite hover:text-ld-violet transition-colors no-underline"
+            >
+              {qaLibraryLink.label}
             </Link>
             {navLinks.map(link => (
               <Link
@@ -141,12 +148,21 @@ const LightdashNavbar: React.FC = () => {
                     </span>
                   </Link>
                 </motion.li>
+                <motion.li initial={{ opacity: 0, x: -12 }} animate={{ opacity: 1, x: 0 }} transition={{ delay: 0.045, duration: 0.18 }}>
+                  <Link
+                    to={qaLibraryLink.to}
+                    onClick={closeMenu}
+                    className="flex items-center px-6 py-4 text-[15px] font-medium text-ld-graphite hover:text-ld-violet hover:bg-ld-cloud transition-colors duration-150 no-underline"
+                  >
+                    {qaLibraryLink.label}
+                  </Link>
+                </motion.li>
                 {navLinks.map((link, idx) => (
                   <motion.li
                     key={link.label}
                     initial={{ opacity: 0, x: -12 }}
                     animate={{ opacity: 1, x: 0 }}
-                    transition={{ delay: (idx + 1) * 0.045, duration: 0.18 }}
+                    transition={{ delay: (idx + 2) * 0.045, duration: 0.18 }}
                   >
                     <Link
                       to={`/${link.href}`}

--- a/src/features/admin/components/shared/QaLibraryMarkdownEditor.tsx
+++ b/src/features/admin/components/shared/QaLibraryMarkdownEditor.tsx
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+interface QaLibraryMarkdownEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+  error?: string | null;
+}
+
+const textareaClass =
+  'w-full h-80 px-3.5 py-2.5 rounded-lg border border-ld-frost bg-white text-sm text-ld-onyx font-mono focus:outline-none focus:border-ld-violet focus:ring-2 focus:ring-ld-lilac resize-y';
+
+// Markdown textarea + live preview, no WYSIWYG dependency — bare
+// <ReactMarkdown> usage matches ProjectCard.tsx's case-study renderer.
+const QaLibraryMarkdownEditor: React.FC<QaLibraryMarkdownEditorProps> = ({ value, onChange, error }) => {
+  const [tab, setTab] = useState<'write' | 'preview'>('write');
+
+  return (
+    <div className="block">
+      <div className="flex items-center gap-1 mb-1.5">
+        <button
+          type="button"
+          onClick={() => setTab('write')}
+          className={`px-3 py-1.5 rounded-lg text-xs font-medium cursor-pointer border-none transition-colors ${tab === 'write' ? 'bg-ld-lilac/60 text-ld-violet' : 'bg-transparent text-ld-fog hover:text-ld-graphite'}`}
+        >
+          Tulis
+        </button>
+        <button
+          type="button"
+          onClick={() => setTab('preview')}
+          className={`px-3 py-1.5 rounded-lg text-xs font-medium cursor-pointer border-none transition-colors ${tab === 'preview' ? 'bg-ld-lilac/60 text-ld-violet' : 'bg-transparent text-ld-fog hover:text-ld-graphite'}`}
+        >
+          Preview
+        </button>
+      </div>
+
+      {tab === 'write' ? (
+        <textarea
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder="Tulis konten artikel dalam format Markdown…"
+          className={textareaClass}
+        />
+      ) : (
+        <div className="w-full h-80 overflow-y-auto px-3.5 py-2.5 rounded-lg border border-ld-frost bg-ld-cloud/40 text-sm text-ld-onyx markdown-body prose max-w-none">
+          {value.trim() ? <ReactMarkdown remarkPlugins={[remarkGfm]}>{value}</ReactMarkdown> : <p className="text-ld-fog italic">Belum ada konten.</p>}
+        </div>
+      )}
+
+      {error && <p className="text-xs text-red-500 mt-1.5" role="alert">{error}</p>}
+    </div>
+  );
+};
+
+export default QaLibraryMarkdownEditor;

--- a/src/features/admin/components/superadmin/QaLibraryArticleForm.tsx
+++ b/src/features/admin/components/superadmin/QaLibraryArticleForm.tsx
@@ -1,0 +1,274 @@
+import React, { useEffect, useState } from 'react';
+import { ArrowLeft } from 'lucide-react';
+import type { QaLibraryArticle, QaLibraryArticleData, QaLibraryArticleStatus, QaLibraryCategory } from '../../../../types/qaLibrary';
+import { slugify, isValidSlug } from '../../../../lib/portfolioValidation';
+import { computeReadingTimeMinutes } from '../../../../lib/qaLibraryValidation';
+import { useAdminUsersStore } from '../../../../store/useAdminUsersStore';
+import ImageUploadField from './ImageUploadField';
+import QaLibraryDocumentUploadField from './QaLibraryDocumentUploadField';
+import QaLibraryAuthorSelect from './QaLibraryAuthorSelect';
+import QaLibraryCategorySelect from './QaLibraryCategorySelect';
+import QaLibraryMarkdownEditor from '../shared/QaLibraryMarkdownEditor';
+import FormField from '../shared/FormField';
+import { ADMIN_CARD, ADMIN_CARD_HEADER, ADMIN_CARD_BODY } from '../shared/adminCard';
+import StatusBadge, { type StatusBadgeTone } from '../shared/StatusBadge';
+
+interface QaLibraryArticleFormProps {
+  onClose: () => void;
+  onSubmit: (payload: QaLibraryArticleData & { slug: string }) => Promise<{ ok: boolean; reason?: string }>;
+  article: QaLibraryArticle | null; // null = create
+  categories: QaLibraryCategory[];
+}
+
+const inputClass =
+  'w-full px-3.5 py-2.5 rounded-lg border border-ld-frost bg-white text-sm text-ld-onyx focus:outline-none focus:border-ld-violet focus:ring-2 focus:ring-ld-lilac';
+
+const STATUS_TONE: Record<QaLibraryArticleStatus, StatusBadgeTone> = {
+  draft: 'slate',
+  published: 'emerald',
+};
+
+const emptyData: QaLibraryArticleData = {
+  title: '',
+  categoryId: '',
+  excerpt: '',
+  body: '',
+  thumbnailUrl: undefined,
+  docUrl: undefined,
+  docFilename: undefined,
+  docSizeBytes: undefined,
+  tags: [],
+  authorName: '',
+  authorUserId: undefined,
+  authorAvatarUrl: undefined,
+  status: 'draft',
+  seoMetaTitle: undefined,
+  seoMetaDescription: undefined,
+  seoOgImage: undefined,
+};
+
+const QaLibraryArticleForm: React.FC<QaLibraryArticleFormProps> = ({ onClose, onSubmit, article, categories }) => {
+  const isEdit = article !== null;
+  const [data, setData] = useState<QaLibraryArticleData>(article ?? { ...emptyData, categoryId: categories[0]?.id ?? '' });
+  const [slug, setSlug] = useState(article?.slug ?? '');
+  const [slugTouched, setSlugTouched] = useState(isEdit);
+  const [tagsInput, setTagsInput] = useState((article?.tags ?? []).join(', '));
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const { users, load: loadUsers } = useAdminUsersStore();
+
+  useEffect(() => { loadUsers(); }, [loadUsers]);
+
+  const handleAuthorChange = (user: { id: string; name: string; avatarUrl: string | null }) => {
+    setData((d) => ({ ...d, authorUserId: user.id, authorName: user.name, authorAvatarUrl: user.avatarUrl ?? undefined }));
+  };
+
+  const handleTitleChange = (title: string) => {
+    setData((d) => ({ ...d, title }));
+    if (!slugTouched) setSlug(slugify(title));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!isValidSlug(slug)) {
+      setError('Slug harus lowercase (a-z, 0-9, tanda hubung).');
+      return;
+    }
+    if (!data.title.trim()) { setError('Title wajib diisi.'); return; }
+    if (!data.categoryId) { setError('Category wajib dipilih.'); return; }
+    if (!data.excerpt.trim()) { setError('Excerpt wajib diisi.'); return; }
+    if (!data.authorName.trim()) { setError('Author wajib dipilih.'); return; }
+    if (!data.body.trim()) { setError('Konten artikel wajib diisi.'); return; }
+    if (data.status === 'published' && !data.thumbnailUrl) {
+      setError('Thumbnail wajib diisi sebelum artikel dipublish.');
+      return;
+    }
+
+    setError(null);
+    setSaving(true);
+    const tags = tagsInput.split(',').map((t) => t.trim()).filter(Boolean);
+    const result = await onSubmit({ ...data, tags, slug });
+    setSaving(false);
+    if (!result.ok) {
+      setError(result.reason ?? 'Gagal menyimpan artikel.');
+      return;
+    }
+    onClose();
+  };
+
+  return (
+    <div className={ADMIN_CARD}>
+      <div className={`${ADMIN_CARD_HEADER} justify-between`}>
+        <div className="flex items-center gap-3">
+          <button
+            onClick={onClose}
+            className="p-1.5 -ml-1 rounded-lg text-ld-fog hover:text-ld-graphite hover:bg-ld-cloud cursor-pointer border-none bg-transparent transition-colors"
+            aria-label="Kembali ke daftar artikel"
+          >
+            <ArrowLeft size={17} />
+          </button>
+          <h2 className="text-sm font-semibold text-ld-onyx m-0">{isEdit ? 'Edit Artikel' : 'Tambah Artikel'}</h2>
+        </div>
+        <StatusBadge tone={STATUS_TONE[data.status]}>{data.status}</StatusBadge>
+      </div>
+
+      <form onSubmit={handleSubmit} className={ADMIN_CARD_BODY}>
+        <div className="grid grid-cols-1 lg:grid-cols-5 gap-6">
+          {/* Left panel — content */}
+          <div className="lg:col-span-3 grid grid-cols-1 md:grid-cols-2 gap-x-4 gap-y-4">
+            <FormField label="Title" required className="md:col-span-2">
+              <input
+                type="text"
+                value={data.title}
+                onChange={(e) => handleTitleChange(e.target.value)}
+                placeholder="Cara Menulis Test Case yang Efektif"
+                className={inputClass}
+              />
+            </FormField>
+
+            <FormField label="Slug" required hint={<span className="block text-[11px] text-ld-fog mt-1">URL: /qa-library/{slug || '…'}</span>}>
+              <input
+                type="text"
+                value={slug}
+                onChange={(e) => { setSlugTouched(true); setSlug(e.target.value); }}
+                placeholder="cara-menulis-test-case-efektif"
+                className={inputClass}
+              />
+            </FormField>
+
+            <FormField label="Category" required>
+              <QaLibraryCategorySelect
+                categories={categories}
+                value={data.categoryId}
+                onChange={(categoryId) => setData({ ...data, categoryId })}
+              />
+            </FormField>
+
+            <FormField label="Excerpt" required className="md:col-span-2" hint={<span className="block text-[11px] text-ld-fog mt-1">Ringkasan singkat.</span>}>
+              <textarea
+                value={data.excerpt}
+                onChange={(e) => setData({ ...data, excerpt: e.target.value })}
+                rows={2}
+                placeholder="Panduan singkat menulis test case yang jelas, ringkas, dan mudah dieksekusi tim QA."
+                className={`${inputClass} resize-y`}
+              />
+            </FormField>
+
+            <div className="md:col-span-2">
+              <FormField
+                label="Konten Artikel"
+                required
+                hint={<span className="block text-[11px] text-ld-fog mt-1">~{computeReadingTimeMinutes(data.body)} menit baca</span>}
+              >
+                <QaLibraryMarkdownEditor value={data.body} onChange={(body) => setData({ ...data, body })} />
+              </FormField>
+            </div>
+
+            <div className="md:col-span-2">
+              <QaLibraryDocumentUploadField
+                label="Dokumen (PDF/PPT, opsional)"
+                value={data.docUrl}
+                filename={data.docFilename}
+                sizeBytes={data.docSizeBytes}
+                onChange={({ url, filename, sizeBytes }) => setData({ ...data, docUrl: url, docFilename: filename, docSizeBytes: sizeBytes })}
+              />
+            </div>
+          </div>
+
+          {/* Right panel — thumbnail, status, SEO */}
+          <div className="lg:col-span-2 flex flex-col gap-4">
+            <ImageUploadField
+              label="Thumbnail"
+              value={data.thumbnailUrl}
+              onChange={(thumbnailUrl) => setData({ ...data, thumbnailUrl })}
+              feature="qaLibrary"
+              maxWidth={1600}
+              ratioHint="Rasio 16:9, mis. 1600x900px"
+            />
+
+            <FormField label="Author" required hint={<span className="block text-[11px] text-ld-fog mt-1">Lookup ke user terdaftar.</span>}>
+              <QaLibraryAuthorSelect users={users} value={data.authorUserId} onChange={handleAuthorChange} />
+            </FormField>
+
+            <FormField label="Tags" hint={<span className="block text-[11px] text-ld-fog mt-1">Pisahkan dengan koma.</span>}>
+              <input
+                type="text"
+                value={tagsInput}
+                onChange={(e) => setTagsInput(e.target.value)}
+                placeholder="test case, manual testing, dokumentasi"
+                className={inputClass}
+              />
+            </FormField>
+
+            <FormField label="Status">
+              <div className="flex items-center gap-2">
+                {(['draft', 'published'] as QaLibraryArticleStatus[]).map((s) => (
+                  <button
+                    key={s}
+                    type="button"
+                    onClick={() => setData({ ...data, status: s })}
+                    className={`px-3.5 py-2 rounded-lg text-sm font-medium cursor-pointer border transition-colors capitalize ${data.status === s ? 'bg-ld-violet text-white border-ld-violet' : 'bg-white text-ld-graphite border-ld-frost hover:border-ld-violet'}`}
+                  >
+                    {s}
+                  </button>
+                ))}
+              </div>
+            </FormField>
+
+            <div className="pt-2 mt-1 border-t border-ld-frost/60">
+              <h3 className="text-xs font-semibold uppercase tracking-widest text-ld-fog mb-3">SEO</h3>
+            </div>
+
+            <FormField label="Meta Title" hint={<span className="block text-[11px] text-ld-fog mt-1">Kosongkan untuk pakai Title.</span>}>
+              <input
+                type="text"
+                value={data.seoMetaTitle ?? ''}
+                onChange={(e) => setData({ ...data, seoMetaTitle: e.target.value || undefined })}
+                className={inputClass}
+              />
+            </FormField>
+
+            <FormField label="Meta Description" hint={<span className="block text-[11px] text-ld-fog mt-1">Kosongkan untuk pakai Excerpt.</span>}>
+              <textarea
+                value={data.seoMetaDescription ?? ''}
+                onChange={(e) => setData({ ...data, seoMetaDescription: e.target.value || undefined })}
+                rows={2}
+                className={`${inputClass} resize-y`}
+              />
+            </FormField>
+
+            <FormField label="OG Image URL" hint={<span className="block text-[11px] text-ld-fog mt-1">Kosongkan untuk pakai Thumbnail.</span>}>
+              <input
+                type="text"
+                value={data.seoOgImage ?? ''}
+                onChange={(e) => setData({ ...data, seoOgImage: e.target.value || undefined })}
+                className={inputClass}
+              />
+            </FormField>
+          </div>
+        </div>
+
+        {error && <p className="text-sm text-red-500 m-0 mt-6">{error}</p>}
+
+        <div className="flex justify-end gap-2 mt-8 pt-5 border-t border-ld-frost/60">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 rounded-lg border border-ld-frost bg-white text-sm text-ld-graphite cursor-pointer"
+          >
+            Batal
+          </button>
+          <button
+            type="submit"
+            disabled={saving}
+            className="px-4 py-2 rounded-lg bg-ld-violet hover:bg-[#1f87e6] text-white text-sm font-medium cursor-pointer border-none disabled:opacity-60 disabled:cursor-not-allowed"
+          >
+            {saving ? 'Menyimpan…' : isEdit ? 'Simpan Artikel' : 'Tambah Artikel'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default QaLibraryArticleForm;

--- a/src/features/admin/components/superadmin/QaLibraryAuthorSelect.tsx
+++ b/src/features/admin/components/superadmin/QaLibraryAuthorSelect.tsx
@@ -1,0 +1,133 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { ChevronDown, Search, User as UserIcon } from 'lucide-react';
+import type { AdminUserRecord } from '../../../../lib/adminApi';
+
+// Searchable single-select with avatar — admin lookup for the article
+// Author field, mirrors MentorSelect.tsx's UX but sources from the
+// registered `users` list instead of mentors.
+interface QaLibraryAuthorSelectProps {
+  users: AdminUserRecord[];
+  value: string | undefined; // authorUserId
+  onChange: (user: AdminUserRecord) => void;
+}
+
+const Avatar: React.FC<{ user: AdminUserRecord; size?: number }> = ({ user, size = 28 }) => (
+  user.avatarUrl ? (
+    <img
+      src={user.avatarUrl}
+      alt=""
+      className="rounded-full object-cover border border-ld-frost shrink-0"
+      style={{ width: size, height: size }}
+    />
+  ) : (
+    <span
+      className="rounded-full bg-ld-cloud border border-ld-frost shrink-0 flex items-center justify-center text-ld-fog"
+      style={{ width: size, height: size }}
+    >
+      <UserIcon size={size * 0.55} />
+    </span>
+  )
+);
+
+const QaLibraryAuthorSelect: React.FC<QaLibraryAuthorSelectProps> = ({ users, value, onChange }) => {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const rootRef = useRef<HTMLDivElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  const closeDropdown = () => { setOpen(false); setQuery(''); };
+
+  useEffect(() => {
+    if (!open) return;
+    const handleClick = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) closeDropdown();
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [open]);
+
+  useEffect(() => {
+    if (open) searchRef.current?.focus();
+  }, [open]);
+
+  const selectedUser = users.find((u) => u.id === value) ?? null;
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return users;
+    return users.filter((u) => u.name.toLowerCase().includes(q) || u.email.toLowerCase().includes(q));
+  }, [users, query]);
+
+  const select = (user: AdminUserRecord) => {
+    onChange(user);
+    closeDropdown();
+  };
+
+  return (
+    <div ref={rootRef}>
+      <div className="relative">
+        <button
+          type="button"
+          onClick={() => (open ? closeDropdown() : setOpen(true))}
+          aria-expanded={open}
+          className="w-full flex items-center justify-between gap-2 px-3 py-2 rounded-lg border border-ld-frost bg-white text-left text-sm cursor-pointer hover:border-ld-violet transition-colors"
+        >
+          {selectedUser ? (
+            <span className="flex items-center gap-2.5 min-w-0">
+              <Avatar user={selectedUser} />
+              <span className="min-w-0">
+                <span className="block text-ld-onyx font-medium truncate">{selectedUser.name}</span>
+                <span className="block text-[11px] text-ld-fog truncate">{selectedUser.email}</span>
+              </span>
+            </span>
+          ) : (
+            <span className="text-ld-fog">Pilih author</span>
+          )}
+          <ChevronDown size={15} className={`text-ld-fog flex-shrink-0 transition-transform ${open ? 'rotate-180' : ''}`} />
+        </button>
+
+        {open && (
+          <div className="absolute z-20 mt-1.5 w-full rounded-xl border border-ld-frost bg-white shadow-[rgba(39,40,53,0.1)_0px_0px_0px_1px,rgba(39,40,53,0.12)_0px_12px_24px_-8px]">
+            <div className="flex items-center gap-2 px-3 py-2.5 border-b border-ld-frost/60">
+              <Search size={14} className="text-ld-fog flex-shrink-0" />
+              <input
+                ref={searchRef}
+                type="text"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Cari user…"
+                className="w-full text-sm outline-none border-none bg-transparent text-ld-onyx placeholder:text-ld-fog"
+              />
+            </div>
+            <div className="max-h-64 overflow-y-auto p-1.5">
+              {filtered.length === 0 && (
+                <p className="px-2.5 py-3 text-xs text-ld-fog text-center m-0">User tidak ditemukan.</p>
+              )}
+              {filtered.map((user) => {
+                const selected = user.id === value;
+                return (
+                  <button
+                    key={user.id}
+                    type="button"
+                    onClick={() => select(user)}
+                    className={`w-full flex items-center gap-2.5 px-2.5 py-2 rounded-lg text-left cursor-pointer border-none transition-colors ${
+                      selected ? 'bg-ld-lilac/60' : 'bg-transparent hover:bg-ld-cloud'
+                    }`}
+                  >
+                    <Avatar user={user} size={32} />
+                    <span className="min-w-0">
+                      <span className="block text-sm font-medium text-ld-onyx truncate">{user.name}</span>
+                      <span className="block text-[11px] text-ld-fog truncate">{user.email}</span>
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default QaLibraryAuthorSelect;

--- a/src/features/admin/components/superadmin/QaLibraryCategoriesTab.tsx
+++ b/src/features/admin/components/superadmin/QaLibraryCategoriesTab.tsx
@@ -1,0 +1,133 @@
+import React, { useEffect, useState } from 'react';
+import { Pencil, Plus, Trash2 } from 'lucide-react';
+import { useAdminQaLibraryCategoriesStore } from '../../../../store/useAdminQaLibraryCategoriesStore';
+import type { QaLibraryCategory } from '../../../../types/qaLibrary';
+import { usePagination } from '../../../../hooks/usePagination';
+import LoadingState from '../../../../components/common/LoadingState';
+import QaLibraryCategoryForm from './QaLibraryCategoryForm';
+import Pagination from '../shared/Pagination';
+import { ADMIN_CARD, ADMIN_CARD_HEADER, ADMIN_CARD_BODY } from '../shared/adminCard';
+
+const QaLibraryCategoriesTab: React.FC = () => {
+  const { categories, loading, loadError, load, upsertCategory, deleteCategory } = useAdminQaLibraryCategoriesStore();
+  const [formOpen, setFormOpen] = useState(false);
+  const [editing, setEditing] = useState<QaLibraryCategory | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const { page, setPage, totalPages, pageItems: pagedCategories } = usePagination(categories);
+
+  useEffect(() => { load(); }, [load]);
+
+  const openCreate = () => { setEditing(null); setFormOpen(true); };
+  const openEdit = (category: QaLibraryCategory) => { setEditing(category); setFormOpen(true); };
+
+  if (formOpen) {
+    return (
+      <QaLibraryCategoryForm
+        onClose={() => setFormOpen(false)}
+        onSubmit={upsertCategory}
+        category={editing}
+        existingIds={categories.map((c) => c.id)}
+      />
+    );
+  }
+
+  const handleDelete = async (category: QaLibraryCategory) => {
+    setDeleteError(null);
+    if (!window.confirm(`Hapus category "${category.label}"?`)) return;
+    setDeletingId(category.id);
+    const result = await deleteCategory(category.id);
+    setDeletingId(null);
+    if (!result.ok) setDeleteError(result.reason ?? 'Gagal menghapus category.');
+  };
+
+  return (
+    <div className={ADMIN_CARD}>
+      <div className={`${ADMIN_CARD_HEADER} justify-between`}>
+        <div>
+          <h2 className="text-sm font-semibold text-ld-onyx m-0">Article Categories</h2>
+          <p className="text-xs text-ld-fog m-0 mt-1">{categories.length} category tersedia untuk artikel QA Library.</p>
+        </div>
+        <button
+          onClick={openCreate}
+          className="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-lg bg-ld-violet hover:bg-[#1f87e6] text-white text-sm font-medium cursor-pointer border-none transition-colors"
+        >
+          <Plus size={14} /> Tambah Category
+        </button>
+      </div>
+
+      <div className={ADMIN_CARD_BODY}>
+        {loadError && (
+          <p className="mb-4 px-4 py-3 rounded-lg bg-red-50 border border-red-200 text-sm text-red-600">{loadError}</p>
+        )}
+        {deleteError && (
+          <p className="mb-4 px-4 py-3 rounded-lg bg-red-50 border border-red-200 text-sm text-red-600">{deleteError}</p>
+        )}
+
+        {loading ? (
+          <LoadingState label="Memuat categories…" />
+        ) : (
+          <>
+            <div className="overflow-x-auto border border-ld-frost rounded-xl">
+              <table className="w-full border-collapse text-sm">
+                <thead>
+                  <tr className="bg-ld-cloud text-left">
+                    <th className="px-4 py-3 text-xs font-medium text-ld-steel">Label</th>
+                    <th className="px-4 py-3 text-xs font-medium text-ld-steel whitespace-nowrap">ID</th>
+                    <th className="px-4 py-3 text-xs font-medium text-ld-steel">Deskripsi</th>
+                    <th className="px-4 py-3 text-xs font-medium text-ld-steel text-right whitespace-nowrap">Aksi</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {pagedCategories.map((category) => (
+                    <tr key={category.id} className="border-t border-ld-frost bg-white hover:bg-ld-cloud/50 transition-colors">
+                      <td className="px-4 py-3">
+                        <button
+                          onClick={() => openEdit(category)}
+                          className="text-sm font-medium text-ld-onyx hover:text-ld-violet hover:underline cursor-pointer border-none bg-transparent p-0 text-left"
+                        >
+                          {category.label}
+                        </button>
+                      </td>
+                      <td className="px-4 py-3 whitespace-nowrap">
+                        <code className="text-[11px] text-ld-slate">{category.id}</code>
+                      </td>
+                      <td className="px-4 py-3 text-xs text-ld-fog">{category.description ?? '—'}</td>
+                      <td className="px-4 py-3">
+                        <div className="flex items-center justify-end gap-1">
+                          <button
+                            onClick={() => openEdit(category)}
+                            className="p-2 rounded-lg text-ld-fog hover:text-ld-violet hover:bg-ld-cloud cursor-pointer border-none bg-transparent transition-colors"
+                            aria-label={`Edit ${category.label}`}
+                          >
+                            <Pencil size={15} />
+                          </button>
+                          <button
+                            onClick={() => handleDelete(category)}
+                            disabled={deletingId === category.id}
+                            className="p-2 rounded-lg text-ld-fog hover:text-red-500 hover:bg-red-50 cursor-pointer border-none bg-transparent transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                            aria-label={`Hapus ${category.label}`}
+                          >
+                            <Trash2 size={15} />
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                  {categories.length === 0 && (
+                    <tr>
+                      <td colSpan={4} className="px-4 py-6 text-center text-sm text-ld-fog">Belum ada category.</td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+            <Pagination page={page} totalPages={totalPages} totalItems={categories.length} pageSize={10} onPageChange={setPage} />
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default QaLibraryCategoriesTab;

--- a/src/features/admin/components/superadmin/QaLibraryCategoryForm.tsx
+++ b/src/features/admin/components/superadmin/QaLibraryCategoryForm.tsx
@@ -1,0 +1,126 @@
+import React, { useState } from 'react';
+import { ArrowLeft } from 'lucide-react';
+import type { QaLibraryCategory } from '../../../../types/qaLibrary';
+import { slugify, isValidSlug } from '../../../../lib/portfolioValidation';
+import { ADMIN_CARD, ADMIN_CARD_HEADER, ADMIN_CARD_BODY } from '../shared/adminCard';
+
+interface QaLibraryCategoryFormProps {
+  onClose: () => void;
+  onSubmit: (category: QaLibraryCategory) => Promise<{ ok: boolean; reason?: string }>;
+  category: QaLibraryCategory | null; // null = create
+  existingIds: string[];
+}
+
+const inputClass =
+  'w-full px-3.5 py-2.5 rounded-lg border border-ld-frost bg-white text-sm text-ld-onyx focus:outline-none focus:border-ld-violet focus:ring-2 focus:ring-ld-lilac';
+
+const emptyCategory: QaLibraryCategory = { id: '', label: '', description: '' };
+
+const QaLibraryCategoryForm: React.FC<QaLibraryCategoryFormProps> = ({ onClose, onSubmit, category, existingIds }) => {
+  const isEdit = category !== null;
+  const [form, setForm] = useState<QaLibraryCategory>(category ?? emptyCategory);
+  const [idTouched, setIdTouched] = useState(isEdit);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const handleLabelChange = (label: string) => {
+    setForm((f) => ({ ...f, label, id: idTouched ? f.id : slugify(label) }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!isValidSlug(form.id)) {
+      setError('ID harus slug lowercase, contoh: manual-testing');
+      return;
+    }
+    if (!isEdit && existingIds.includes(form.id)) {
+      setError(`ID "${form.id}" sudah dipakai category lain.`);
+      return;
+    }
+    if (!form.label.trim()) {
+      setError('Label wajib diisi.');
+      return;
+    }
+    setError(null);
+    setSaving(true);
+    const result = await onSubmit({ ...form, description: form.description?.trim() || undefined });
+    setSaving(false);
+    if (!result.ok) {
+      setError(result.reason ?? 'Gagal menyimpan category.');
+      return;
+    }
+    onClose();
+  };
+
+  return (
+    <div className={ADMIN_CARD}>
+      <div className={ADMIN_CARD_HEADER}>
+        <button
+          onClick={onClose}
+          className="p-1.5 -ml-1 rounded-lg text-ld-fog hover:text-ld-graphite hover:bg-ld-cloud cursor-pointer border-none bg-transparent transition-colors"
+          aria-label="Kembali ke daftar category"
+        >
+          <ArrowLeft size={17} />
+        </button>
+        <h2 className="text-sm font-semibold text-ld-onyx m-0">{isEdit ? 'Edit Category' : 'Tambah Category'}</h2>
+      </div>
+
+      <form onSubmit={handleSubmit} className={`${ADMIN_CARD_BODY} w-full max-w-lg`}>
+        <div className="grid grid-cols-1 gap-y-4">
+          <label className="block">
+            <span className="block text-xs font-medium text-ld-graphite mb-1.5">Label</span>
+            <input
+              type="text"
+              value={form.label}
+              onChange={(e) => handleLabelChange(e.target.value)}
+              placeholder="Manual Testing"
+              className={inputClass}
+            />
+          </label>
+          <label className="block">
+            <span className="block text-xs font-medium text-ld-graphite mb-1.5">ID (slug, tidak bisa diubah setelah dibuat)</span>
+            <input
+              type="text"
+              value={form.id}
+              disabled={isEdit}
+              onChange={(e) => { setIdTouched(true); setForm({ ...form, id: e.target.value }); }}
+              placeholder="manual-testing"
+              className={`${inputClass} disabled:bg-ld-cloud disabled:text-ld-fog`}
+            />
+          </label>
+          <label className="block">
+            <span className="block text-xs font-medium text-ld-graphite mb-1.5">Deskripsi (opsional)</span>
+            <textarea
+              value={form.description ?? ''}
+              onChange={(e) => setForm({ ...form, description: e.target.value })}
+              rows={3}
+              placeholder="Artikel seputar teknik manual testing…"
+              className={`${inputClass} resize-y`}
+            />
+          </label>
+        </div>
+
+        {error && <p className="text-sm text-red-500 m-0 mt-6">{error}</p>}
+
+        <div className="flex justify-end gap-2 mt-8 pt-5 border-t border-ld-frost/60">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 rounded-lg border border-ld-frost bg-white text-sm text-ld-graphite cursor-pointer"
+          >
+            Batal
+          </button>
+          <button
+            type="submit"
+            disabled={saving}
+            className="px-4 py-2 rounded-lg bg-ld-violet hover:bg-[#1f87e6] text-white text-sm font-medium cursor-pointer border-none disabled:opacity-60 disabled:cursor-not-allowed"
+          >
+            {saving ? 'Menyimpan…' : isEdit ? 'Simpan Category' : 'Tambah Category'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default QaLibraryCategoryForm;

--- a/src/features/admin/components/superadmin/QaLibraryCategorySelect.tsx
+++ b/src/features/admin/components/superadmin/QaLibraryCategorySelect.tsx
@@ -1,0 +1,154 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { ChevronDown, Loader2, Plus, Search } from 'lucide-react';
+import type { QaLibraryCategory } from '../../../../types/qaLibrary';
+import { slugify } from '../../../../lib/portfolioValidation';
+import { useAdminQaLibraryCategoriesStore } from '../../../../store/useAdminQaLibraryCategoriesStore';
+
+// Searchable single-select for the article Category field, with inline
+// "add category" — mirrors PortfolioSkillsField.tsx's create-on-the-fly UX
+// (typing a name that doesn't match an existing category offers to create
+// it via the categories store, same as the dedicated Article Categories tab).
+interface QaLibraryCategorySelectProps {
+  categories: QaLibraryCategory[];
+  value: string;
+  onChange: (categoryId: string) => void;
+  error?: string | null;
+}
+
+const QaLibraryCategorySelect: React.FC<QaLibraryCategorySelectProps> = ({ categories, value, onChange, error }) => {
+  const upsertCategory = useAdminQaLibraryCategoriesStore((s) => s.upsertCategory);
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  const closeDropdown = () => { setOpen(false); setQuery(''); setCreateError(null); };
+
+  useEffect(() => {
+    if (!open) return;
+    const handleClick = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) closeDropdown();
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [open]);
+
+  useEffect(() => {
+    if (open) searchRef.current?.focus();
+  }, [open]);
+
+  const selectedCategory = categories.find((c) => c.id === value) ?? null;
+  const q = query.trim().toLowerCase();
+
+  const filtered = useMemo(
+    () => (q ? categories.filter((c) => c.label.toLowerCase().includes(q)) : categories),
+    [categories, q]
+  );
+  const exactMatch = q.length > 0 && categories.some((c) => c.label.toLowerCase() === q);
+  const canCreate = q.length > 0 && !exactMatch;
+
+  const select = (categoryId: string) => {
+    onChange(categoryId);
+    closeDropdown();
+  };
+
+  const createAndSelect = async () => {
+    const label = query.trim();
+    if (!label) return;
+    const id = slugify(label);
+
+    // Different labels can slugify to the same id (e.g. "API Testing!" vs an
+    // existing "API Testing") — upsertCategory replaces by id, so creating
+    // here would silently rename/overwrite that unrelated existing category.
+    // Reuse it instead of writing.
+    const collision = categories.find((c) => c.id === id);
+    if (collision) {
+      select(collision.id);
+      return;
+    }
+
+    setCreateError(null);
+    setCreating(true);
+    const result = await upsertCategory({ id, label });
+    setCreating(false);
+    if (!result.ok) {
+      setCreateError(result.reason ?? `Gagal menambah category "${label}".`);
+      return;
+    }
+    select(id);
+  };
+
+  return (
+    <div ref={rootRef}>
+      <div className="relative">
+        <button
+          type="button"
+          onClick={() => (open ? closeDropdown() : setOpen(true))}
+          aria-expanded={open}
+          className={`w-full flex items-center justify-between gap-2 px-3.5 py-2.5 rounded-lg border bg-white text-left text-sm cursor-pointer transition-colors ${
+            error ? 'border-red-500' : 'border-ld-frost hover:border-ld-violet'
+          }`}
+        >
+          <span className={selectedCategory ? 'text-ld-onyx font-medium truncate' : 'text-ld-fog'}>
+            {selectedCategory ? selectedCategory.label : 'Pilih category…'}
+          </span>
+          <ChevronDown size={15} className={`text-ld-fog flex-shrink-0 transition-transform ${open ? 'rotate-180' : ''}`} />
+        </button>
+
+        {open && (
+          <div className="absolute z-20 mt-1.5 w-full rounded-xl border border-ld-frost bg-white shadow-[rgba(39,40,53,0.1)_0px_0px_0px_1px,rgba(39,40,53,0.12)_0px_12px_24px_-8px]">
+            <div className="flex items-center gap-2 px-3 py-2.5 border-b border-ld-frost/60">
+              <Search size={14} className="text-ld-fog flex-shrink-0" />
+              <input
+                ref={searchRef}
+                type="text"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Cari category… (atau ketik nama baru)"
+                className="w-full text-sm outline-none border-none bg-transparent text-ld-onyx placeholder:text-ld-fog"
+              />
+            </div>
+            <div className="max-h-64 overflow-y-auto p-1.5">
+              {filtered.length === 0 && !canCreate && (
+                <p className="px-2.5 py-3 text-xs text-ld-fog text-center m-0">Category tidak ditemukan.</p>
+              )}
+              {filtered.map((category) => {
+                const selected = category.id === value;
+                return (
+                  <button
+                    key={category.id}
+                    type="button"
+                    onClick={() => select(category.id)}
+                    className={`w-full flex items-center gap-2.5 px-2.5 py-2 rounded-lg text-left cursor-pointer border-none transition-colors ${
+                      selected ? 'bg-ld-lilac/60' : 'bg-transparent hover:bg-ld-cloud'
+                    }`}
+                  >
+                    <span className="text-sm font-medium text-ld-onyx truncate">{category.label}</span>
+                  </button>
+                );
+              })}
+              {canCreate && (
+                <button
+                  type="button"
+                  onClick={createAndSelect}
+                  disabled={creating}
+                  className="w-full flex items-center gap-2.5 px-2.5 py-2 rounded-lg text-left cursor-pointer border-none bg-transparent hover:bg-ld-cloud text-ld-violet disabled:opacity-60 disabled:cursor-not-allowed"
+                >
+                  {creating ? <Loader2 size={14} className="animate-spin shrink-0" /> : <Plus size={14} className="shrink-0" />}
+                  <span className="text-sm">Tambah category "{query.trim()}"</span>
+                </button>
+              )}
+            </div>
+            {createError && <p className="text-xs text-red-500 px-3 pb-2.5 m-0">{createError}</p>}
+          </div>
+        )}
+      </div>
+
+      {error && <p className="text-xs text-red-500 mt-1.5" role="alert">{error}</p>}
+    </div>
+  );
+};
+
+export default QaLibraryCategorySelect;

--- a/src/features/admin/components/superadmin/QaLibraryDocumentUploadField.tsx
+++ b/src/features/admin/components/superadmin/QaLibraryDocumentUploadField.tsx
@@ -1,0 +1,128 @@
+import React, { useRef, useState } from 'react';
+import { upload } from '@vercel/blob/client';
+import { FileText, Loader2, Trash2, Upload } from 'lucide-react';
+import { useAdminAuthStore } from '../../../../store/useAdminAuthStore';
+import { useSnackbarStore } from '../../../../store/useSnackbarStore';
+
+// Client-direct-to-Blob upload for the QA Library document field (PDF/PPT) —
+// bypasses /api/upload's base64-JSON 2MB cap since slide decks can be tens
+// of MB. Posts straight from the browser to Blob storage; only the small
+// token request hits /api/blob-upload (see api/_endpoints/blob-upload.ts).
+const MAX_BYTES = 50 * 1024 * 1024;
+const ALLOWED_TYPES = new Set([
+  'application/pdf',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  'application/ms-powerpoint',
+  'application/vnd.ms-powerpoint',
+]);
+
+function formatBytes(bytes: number | undefined): string {
+  if (!bytes) return '';
+  const mb = bytes / (1024 * 1024);
+  return mb >= 1 ? `${mb.toFixed(1)} MB` : `${Math.ceil(bytes / 1024)} KB`;
+}
+
+interface QaLibraryDocumentUploadFieldProps {
+  label: string;
+  value: string | undefined;
+  filename: string | undefined;
+  sizeBytes: number | undefined;
+  onChange: (next: { url: string | undefined; filename: string | undefined; sizeBytes: number | undefined }) => void;
+}
+
+const QaLibraryDocumentUploadField: React.FC<QaLibraryDocumentUploadFieldProps> = ({ label, value, filename, sizeBytes, onChange }) => {
+  const token = useAdminAuthStore((s) => s.token);
+  const user = useAdminAuthStore((s) => s.user);
+  const showSnackbar = useSnackbarStore((s) => s.show);
+  const [uploading, setUploading] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleFile = async (file: File | undefined) => {
+    if (!file || !token) return;
+    setError(null);
+    if (!ALLOWED_TYPES.has(file.type)) {
+      const msg = 'Format harus PDF atau PPT/PPTX.';
+      setError(msg);
+      showSnackbar(msg, 'error');
+      return;
+    }
+    if (file.size > MAX_BYTES) {
+      const msg = `Ukuran file maksimal ${MAX_BYTES / (1024 * 1024)}MB.`;
+      setError(msg);
+      showSnackbar(msg, 'error');
+      return;
+    }
+    setUploading(true);
+    setProgress(0);
+    try {
+      // Matches FOLDER_BY_FEATURE's key convention in api/_endpoints/upload.ts
+      // (Mentor/Portfolio/etc all group under `<Folder>/<email>/<timestamp>-<filename>`).
+      const pathname = `QaLibrary/${user?.email ?? 'unknown'}/${Date.now()}-${file.name}`;
+      const blob = await upload(pathname, file, {
+        access: 'public',
+        handleUploadUrl: '/api/blob-upload',
+        headers: { Authorization: `Bearer ${token}` },
+        onUploadProgress: ({ percentage }) => setProgress(percentage),
+      });
+      onChange({ url: blob.url, filename: file.name, sizeBytes: file.size });
+      showSnackbar('Dokumen berhasil diunggah!', 'success');
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Gagal upload dokumen.';
+      setError(msg);
+      showSnackbar(msg, 'error');
+    } finally {
+      setUploading(false);
+      if (inputRef.current) inputRef.current.value = '';
+    }
+  };
+
+  return (
+    <div className="block">
+      <span className="block text-xs font-medium text-ld-graphite mb-1.5">{label}</span>
+      <div className="flex items-start gap-3">
+        <span className={`w-20 h-20 rounded-lg border border-ld-frost shrink-0 flex items-center justify-center ${value ? 'bg-ld-lilac/30 text-ld-violet' : 'bg-ld-cloud text-ld-fog'}`}>
+          <FileText size={22} />
+        </span>
+        <div className="flex flex-col gap-2 min-w-0">
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => inputRef.current?.click()}
+              disabled={uploading}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-ld-frost bg-white text-xs font-medium text-ld-graphite hover:border-ld-violet cursor-pointer disabled:opacity-60 disabled:cursor-not-allowed"
+            >
+              {uploading ? <Loader2 size={13} className="animate-spin" /> : <Upload size={13} />}
+              {uploading ? `Mengunggah… ${progress}%` : value ? 'Ganti dokumen' : 'Unggah dokumen'}
+            </button>
+            {value && (
+              <button
+                type="button"
+                onClick={() => onChange({ url: undefined, filename: undefined, sizeBytes: undefined })}
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-ld-frost bg-white text-xs font-medium text-ld-fog hover:text-red-500 hover:border-red-200 cursor-pointer"
+              >
+                <Trash2 size={13} /> Hapus dokumen
+              </button>
+            )}
+          </div>
+          {value && (
+            <a href={value} target="_blank" rel="noopener noreferrer" className="text-[11px] text-ld-violet hover:underline truncate" title={filename}>
+              {filename ?? value} {sizeBytes ? `(${formatBytes(sizeBytes)})` : ''}
+            </a>
+          )}
+        </div>
+        <input
+          ref={inputRef}
+          type="file"
+          accept=".pdf,.ppt,.pptx,application/pdf,application/vnd.openxmlformats-officedocument.presentationml.presentation,application/vnd.ms-powerpoint"
+          onChange={(e) => handleFile(e.target.files?.[0])}
+          className="hidden"
+        />
+      </div>
+      {error && <p className="text-xs text-red-500 mt-1.5" role="alert">{error}</p>}
+    </div>
+  );
+};
+
+export default QaLibraryDocumentUploadField;

--- a/src/features/admin/components/superadmin/QaLibraryTab.tsx
+++ b/src/features/admin/components/superadmin/QaLibraryTab.tsx
@@ -1,0 +1,179 @@
+import React, { useEffect, useState } from 'react';
+import { Pencil, Plus, Trash2 } from 'lucide-react';
+import { useAdminQaLibraryStore } from '../../../../store/useAdminQaLibraryStore';
+import { useAdminQaLibraryCategoriesStore } from '../../../../store/useAdminQaLibraryCategoriesStore';
+import type { QaLibraryArticleSummary } from '../../../../types/qaLibrary';
+import { usePagination } from '../../../../hooks/usePagination';
+import { sortByUpdatedAtDesc } from '../../../../lib/sortByUpdatedAt';
+import LoadingState from '../../../../components/common/LoadingState';
+import QaLibraryArticleForm from './QaLibraryArticleForm';
+import Pagination from '../shared/Pagination';
+import { ADMIN_CARD, ADMIN_CARD_HEADER, ADMIN_CARD_BODY } from '../shared/adminCard';
+import StatusBadge, { type StatusBadgeTone } from '../shared/StatusBadge';
+
+const STATUS_TONE: Record<QaLibraryArticleSummary['status'], StatusBadgeTone> = {
+  draft: 'slate',
+  published: 'emerald',
+};
+
+const QaLibraryTab: React.FC = () => {
+  const { articles, loading, loadError, load, current, currentLoading, loadOne, clearCurrent, create, update, remove } = useAdminQaLibraryStore();
+  const { categories, load: loadCategories } = useAdminQaLibraryCategoriesStore();
+  const [formOpen, setFormOpen] = useState(false);
+  const [mode, setMode] = useState<'create' | 'edit'>('create');
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [deletingSlug, setDeletingSlug] = useState<string | null>(null);
+  const sorted = sortByUpdatedAtDesc(articles);
+  const { page, setPage, totalPages, pageItems: pagedArticles } = usePagination(sorted);
+  const categoryLabel = (id: string) => categories.find((c) => c.id === id)?.label ?? id;
+
+  useEffect(() => { load(); loadCategories(); }, [load, loadCategories]);
+
+  const openCreate = () => { clearCurrent(); setMode('create'); setFormOpen(true); };
+  const openEdit = async (slug: string) => {
+    setMode('edit');
+    setFormOpen(true);
+    await loadOne(slug);
+  };
+  const closeForm = () => { setFormOpen(false); clearCurrent(); };
+
+  const handleDelete = async (article: QaLibraryArticleSummary) => {
+    setDeleteError(null);
+    if (!window.confirm(`Hapus artikel "${article.title}"?`)) return;
+    setDeletingSlug(article.slug);
+    const result = await remove(article.slug);
+    setDeletingSlug(null);
+    if (!result.ok) setDeleteError(result.reason ?? 'Gagal menghapus artikel.');
+  };
+
+  if (formOpen) {
+    if (mode === 'edit' && currentLoading) {
+      return (
+        <div className={`${ADMIN_CARD} ${ADMIN_CARD_BODY}`}>
+          <LoadingState label="Memuat artikel…" />
+        </div>
+      );
+    }
+    return (
+      <QaLibraryArticleForm
+        onClose={closeForm}
+        onSubmit={(payload) => (mode === 'edit' && current ? update(current.slug, payload) : create(payload))}
+        article={mode === 'edit' ? current : null}
+        categories={categories}
+      />
+    );
+  }
+
+  return (
+    <div className={ADMIN_CARD}>
+      <div className={`${ADMIN_CARD_HEADER} justify-between`}>
+        <div>
+          <h2 className="text-sm font-semibold text-ld-onyx m-0">Articles</h2>
+          <p className="text-xs text-ld-fog m-0 mt-1">{articles.length} artikel QA Library.</p>
+        </div>
+        <button
+          onClick={openCreate}
+          className="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-lg bg-ld-violet hover:bg-[#1f87e6] text-white text-sm font-medium cursor-pointer border-none transition-colors"
+        >
+          <Plus size={14} /> Tambah Artikel
+        </button>
+      </div>
+
+      <div className={ADMIN_CARD_BODY}>
+        {loadError && (
+          <p className="mb-4 px-4 py-3 rounded-lg bg-red-50 border border-red-200 text-sm text-red-600">{loadError}</p>
+        )}
+        {deleteError && (
+          <p className="mb-4 px-4 py-3 rounded-lg bg-red-50 border border-red-200 text-sm text-red-600">{deleteError}</p>
+        )}
+
+        {loading ? (
+          <LoadingState label="Memuat artikel…" />
+        ) : (
+          <>
+            <div className="overflow-x-auto border border-ld-frost rounded-xl">
+              <table className="w-full border-collapse text-sm">
+                <thead>
+                  <tr className="bg-ld-cloud text-left">
+                    <th className="px-4 py-3 text-xs font-medium text-ld-steel">Title</th>
+                    <th className="px-4 py-3 text-xs font-medium text-ld-steel whitespace-nowrap">Category</th>
+                    <th className="px-4 py-3 text-xs font-medium text-ld-steel whitespace-nowrap">Author</th>
+                    <th className="px-4 py-3 text-xs font-medium text-ld-steel whitespace-nowrap">Status</th>
+                    <th className="px-4 py-3 text-xs font-medium text-ld-steel whitespace-nowrap">Diperbarui</th>
+                    <th className="px-4 py-3 text-xs font-medium text-ld-steel text-right whitespace-nowrap">Aksi</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {pagedArticles.map((article) => (
+                    <tr key={article.id} className="border-t border-ld-frost bg-white hover:bg-ld-cloud/50 transition-colors">
+                      <td className="px-4 py-3">
+                        <div className="flex items-center gap-3 min-w-[180px]">
+                          {article.thumbnailUrl ? (
+                            <img src={article.thumbnailUrl} alt="" className="w-9 h-9 rounded-lg object-cover object-top border border-ld-frost shrink-0" />
+                          ) : (
+                            <span className="w-9 h-9 rounded-lg bg-ld-cloud border border-ld-frost shrink-0" />
+                          )}
+                          <button
+                            onClick={() => openEdit(article.slug)}
+                            className="text-sm font-medium text-ld-onyx hover:text-ld-violet hover:underline cursor-pointer border-none bg-transparent p-0 text-left"
+                          >
+                            {article.title}
+                          </button>
+                        </div>
+                      </td>
+                      <td className="px-4 py-3 text-xs text-ld-fog whitespace-nowrap">{categoryLabel(article.categoryId)}</td>
+                      <td className="px-4 py-3 whitespace-nowrap">
+                        <div className="flex items-center gap-2">
+                          {article.authorAvatarUrl ? (
+                            <img src={article.authorAvatarUrl} alt="" className="w-6 h-6 rounded-full object-cover object-top border border-ld-frost shrink-0" />
+                          ) : (
+                            <span className="w-6 h-6 rounded-full bg-ld-cloud border border-ld-frost shrink-0" />
+                          )}
+                          <span className="text-xs text-ld-fog">{article.authorName}</span>
+                        </div>
+                      </td>
+                      <td className="px-4 py-3 whitespace-nowrap">
+                        <StatusBadge tone={STATUS_TONE[article.status]}>{article.status}</StatusBadge>
+                      </td>
+                      <td className="px-4 py-3 text-xs text-ld-slate whitespace-nowrap">
+                        {new Date(article.updatedAt).toLocaleDateString('id-ID')}{' '}
+                        {new Date(article.updatedAt).toLocaleTimeString('id-ID', { hour: '2-digit', minute: '2-digit' })}
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="flex items-center justify-end gap-1">
+                          <button
+                            onClick={() => openEdit(article.slug)}
+                            className="p-2 rounded-lg text-ld-fog hover:text-ld-violet hover:bg-ld-cloud cursor-pointer border-none bg-transparent transition-colors"
+                            aria-label={`Edit ${article.title}`}
+                          >
+                            <Pencil size={15} />
+                          </button>
+                          <button
+                            onClick={() => handleDelete(article)}
+                            disabled={deletingSlug === article.slug}
+                            className="p-2 rounded-lg text-ld-fog hover:text-red-500 hover:bg-red-50 cursor-pointer border-none bg-transparent transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                            aria-label={`Hapus ${article.title}`}
+                          >
+                            <Trash2 size={15} />
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                  {articles.length === 0 && (
+                    <tr>
+                      <td colSpan={6} className="px-4 py-6 text-center text-sm text-ld-fog">Belum ada artikel.</td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+            <Pagination page={page} totalPages={totalPages} totalItems={sorted.length} pageSize={10} onPageChange={setPage} />
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default QaLibraryTab;

--- a/src/features/qa-library/components/QaLibraryArticleCard.tsx
+++ b/src/features/qa-library/components/QaLibraryArticleCard.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { ArrowRight, Clock, User } from 'lucide-react';
+import type { QaLibraryArticleSummary } from '../../../types/qaLibrary';
+
+interface QaLibraryArticleCardProps {
+  article: QaLibraryArticleSummary;
+  categoryLabel: string;
+}
+
+const QaLibraryArticleCard: React.FC<QaLibraryArticleCardProps> = ({ article, categoryLabel }) => (
+  <Link
+    to={`/qa-library/${article.slug}`}
+    className="group flex flex-col rounded-xl border border-ld-frost bg-white overflow-hidden no-underline hover:border-ld-violet hover:shadow-[0_8px_24px_rgba(30,27,75,0.08)] transition-all"
+  >
+    <div className="aspect-video w-full bg-ld-cloud overflow-hidden">
+      {article.thumbnailUrl ? (
+        <img
+          src={article.thumbnailUrl}
+          alt={article.title}
+          className="w-full h-full object-cover object-top group-hover:scale-105 transition-transform duration-300"
+        />
+      ) : (
+        <div className="w-full h-full flex items-center justify-center text-ld-fog text-xs">Tanpa thumbnail</div>
+      )}
+    </div>
+    <div className="flex flex-col flex-1 p-4">
+      <span className="inline-block w-fit px-2 py-0.5 rounded-md text-[10px] font-semibold uppercase tracking-widest bg-ld-lilac text-ld-violet mb-2">
+        {categoryLabel}
+      </span>
+      <h3 className="font-ld-display font-semibold text-base text-ld-onyx leading-snug mb-2 line-clamp-2">
+        {article.title}
+      </h3>
+      <p className="text-sm text-ld-slate leading-relaxed line-clamp-2 mb-3">{article.excerpt}</p>
+
+      <div className="flex items-center gap-2 mb-3">
+        {article.authorAvatarUrl ? (
+          <img src={article.authorAvatarUrl} alt="" className="w-5 h-5 rounded-full object-cover object-top border border-ld-frost shrink-0" />
+        ) : (
+          <span className="w-5 h-5 rounded-full bg-ld-cloud border border-ld-frost shrink-0 flex items-center justify-center text-ld-fog">
+            <User size={11} />
+          </span>
+        )}
+        <span className="text-xs text-ld-slate truncate">{article.authorName}</span>
+      </div>
+
+      <div className="mt-auto flex items-center justify-between gap-2">
+        <div className="flex items-center gap-1.5 text-xs text-ld-fog">
+          <Clock size={13} />
+          <span>{article.readingTimeMinutes} menit baca</span>
+        </div>
+        <span className="inline-flex items-center gap-1 text-xs font-medium text-ld-violet">
+          Read More
+          <ArrowRight size={13} className="group-hover:translate-x-0.5 transition-transform" />
+        </span>
+      </div>
+    </div>
+  </Link>
+);
+
+export default QaLibraryArticleCard;

--- a/src/features/qa-library/components/QaLibraryCategoryFilter.tsx
+++ b/src/features/qa-library/components/QaLibraryCategoryFilter.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import type { QaLibraryCategory } from '../../../types/qaLibrary';
+
+interface QaLibraryCategoryFilterProps {
+  categories: QaLibraryCategory[];
+  activeCategoryId: string | undefined;
+  onChange: (categoryId: string | undefined) => void;
+}
+
+const QaLibraryCategoryFilter: React.FC<QaLibraryCategoryFilterProps> = ({ categories, activeCategoryId, onChange }) => (
+  <div className="flex flex-wrap gap-2">
+    <button
+      onClick={() => onChange(undefined)}
+      className={`px-3.5 py-1.5 rounded-full text-sm font-medium cursor-pointer border transition-colors ${!activeCategoryId ? 'bg-ld-violet text-white border-ld-violet' : 'bg-white text-ld-graphite border-ld-frost hover:border-ld-violet'}`}
+    >
+      Semua
+    </button>
+    {categories.map((category) => (
+      <button
+        key={category.id}
+        onClick={() => onChange(category.id)}
+        className={`px-3.5 py-1.5 rounded-full text-sm font-medium cursor-pointer border transition-colors ${activeCategoryId === category.id ? 'bg-ld-violet text-white border-ld-violet' : 'bg-white text-ld-graphite border-ld-frost hover:border-ld-violet'}`}
+      >
+        {category.label}
+      </button>
+    ))}
+  </div>
+);
+
+export default QaLibraryCategoryFilter;

--- a/src/features/qa-library/hooks/useQaLibraryArticle.ts
+++ b/src/features/qa-library/hooks/useQaLibraryArticle.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+import type { QaLibraryArticle } from '../../../types/qaLibrary';
+
+interface UseQaLibraryArticleResult {
+  article: QaLibraryArticle | null;
+  loading: boolean;
+  notFound: boolean;
+  error: string | null;
+}
+
+// Public read-by-slug — GET /api/qa-library/:slug. 404 (draft or missing)
+// surfaces as notFound, distinct from a network/server error.
+export function useQaLibraryArticle(slug: string | undefined): UseQaLibraryArticleResult {
+  const [article, setArticle] = useState<QaLibraryArticle | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const key = slug ?? '';
+
+  useEffect(() => {
+    if (!slug) { setLoading(false); setNotFound(true); return; }
+    let cancelled = false;
+    setLoading(true);
+    setNotFound(false);
+    setError(null);
+
+    fetch(`/api/qa-library/${encodeURIComponent(slug)}`)
+      .then((res) => {
+        if (res.status === 404) { if (!cancelled) setNotFound(true); return null; }
+        if (!res.ok) throw new Error(`Gagal memuat artikel (HTTP ${res.status}).`);
+        return res.json();
+      })
+      .then((data: QaLibraryArticle | null) => {
+        if (!cancelled && data) setArticle(data);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Gagal memuat artikel.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
+
+  return { article, loading, notFound, error };
+}

--- a/src/features/qa-library/hooks/useQaLibraryArticles.ts
+++ b/src/features/qa-library/hooks/useQaLibraryArticles.ts
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react';
+import type { QaLibraryArticleSummary } from '../../../types/qaLibrary';
+
+interface UseQaLibraryArticlesResult {
+  articles: QaLibraryArticleSummary[];
+  loading: boolean;
+  error: string | null;
+  retry: () => void;
+}
+
+// Public list of published articles, optionally filtered by category —
+// GET /api/qa-library?category=.
+export function useQaLibraryArticles(categoryId?: string): UseQaLibraryArticlesResult {
+  const [articles, setArticles] = useState<QaLibraryArticleSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [attempt, setAttempt] = useState(0);
+  const key = `${categoryId ?? ''}:${attempt}`;
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    const params = categoryId ? `?category=${encodeURIComponent(categoryId)}` : '';
+    fetch(`/api/qa-library${params}`)
+      .then((res) => {
+        if (!res.ok) throw new Error(`Gagal memuat artikel (HTTP ${res.status}).`);
+        return res.json();
+      })
+      .then((data: { articles: QaLibraryArticleSummary[] }) => {
+        if (!cancelled) setArticles(data.articles);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Gagal memuat artikel.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
+
+  return { articles, loading, error, retry: () => setAttempt((a) => a + 1) };
+}

--- a/src/features/qa-library/hooks/useQaLibraryCategories.ts
+++ b/src/features/qa-library/hooks/useQaLibraryCategories.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+import type { QaLibraryCategory } from '../../../types/qaLibrary';
+
+// Public read of the category taxonomy — GET /api/admin-config/qa-library-categories.
+export function useQaLibraryCategories(): { categories: QaLibraryCategory[]; loading: boolean } {
+  const [categories, setCategories] = useState<QaLibraryCategory[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch('/api/admin-config/qa-library-categories')
+      .then((res) => (res.ok ? res.json() : { categories: [] }))
+      .then((data: { categories: QaLibraryCategory[] }) => {
+        if (!cancelled) setCategories(data.categories ?? []);
+      })
+      .catch(() => { /* non-fatal — filter chips just won't show */ })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  return { categories, loading };
+}

--- a/src/features/qa-library/pages/QaLibraryArticleDetailPage.tsx
+++ b/src/features/qa-library/pages/QaLibraryArticleDetailPage.tsx
@@ -1,0 +1,160 @@
+import React from 'react';
+import { useParams, Link } from 'react-router-dom';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { ArrowLeft, CalendarDays, Clock, Download, Eye, User } from 'lucide-react';
+import { useQaLibraryArticle } from '../hooks/useQaLibraryArticle';
+import { useQaLibraryArticles } from '../hooks/useQaLibraryArticles';
+import { useQaLibraryCategories } from '../hooks/useQaLibraryCategories';
+import QaLibraryArticleCard from '../components/QaLibraryArticleCard';
+import Seo from '../../../components/common/Seo';
+import LoadingState from '../../../components/common/LoadingState';
+import NotFoundState from '../../../components/common/NotFoundState';
+
+function formatBytes(bytes: number | undefined): string {
+  if (!bytes) return '';
+  const mb = bytes / (1024 * 1024);
+  return mb >= 1 ? `${mb.toFixed(1)} MB` : `${Math.ceil(bytes / 1024)} KB`;
+}
+
+function formatUpdatedDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+const QaLibraryArticleDetailPage: React.FC = () => {
+  const { slug } = useParams<{ slug: string }>();
+  const { article, loading, notFound, error } = useQaLibraryArticle(slug);
+  const { categories } = useQaLibraryCategories();
+  const { articles: allArticles } = useQaLibraryArticles();
+
+  if (loading) {
+    return <LoadingState className="min-h-[60vh] pt-16" />;
+  }
+
+  if (notFound || error || !article) {
+    return (
+      <div className="flex items-center justify-center min-h-[60vh] px-4 font-ld-sans">
+        <NotFoundState
+          illustrationLabel="?"
+          title="Artikel tidak ditemukan"
+          description="Artikel yang kamu cari tidak tersedia atau sudah dipindahkan."
+          actionTo="/qa-library"
+          actionLabel="Kembali ke QA Library"
+          actionIcon={<ArrowLeft size={16} />}
+        />
+      </div>
+    );
+  }
+
+  const categoryLabel = categories.find((c) => c.id === article.categoryId)?.label ?? article.categoryId;
+  const categoryLabelFor = (id: string) => categories.find((c) => c.id === id)?.label ?? id;
+
+  // Summary rows don't carry authorUserId, only authorName — match on that.
+  const moreFromAuthor = allArticles
+    .filter((a) => a.id !== article.id && a.authorName === article.authorName)
+    .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
+    .slice(0, 3);
+
+  return (
+    <article className="font-ld-sans pb-16">
+      <Seo
+        path={`/qa-library/${article.slug}`}
+        title={article.seoMetaTitle || `${article.title} | QA Library`}
+        description={article.seoMetaDescription || article.excerpt}
+        image={article.seoOgImage || article.thumbnailUrl}
+        noindex={article.status !== 'published'}
+        jsonLd={{
+          '@context': 'https://schema.org',
+          '@type': 'Article',
+          headline: article.title,
+          description: article.excerpt,
+          image: article.thumbnailUrl ? [article.thumbnailUrl] : undefined,
+          datePublished: article.createdAt,
+          dateModified: article.updatedAt,
+          author: { '@type': 'Person', name: article.authorName },
+          mainEntityOfPage: { '@type': 'WebPage', '@id': `https://www.mentorqa.com/qa-library/${article.slug}` },
+        }}
+      />
+
+      <div className="max-w-3xl mx-auto px-4 pt-24 md:pt-28">
+        <Link
+          to="/qa-library"
+          className="inline-flex items-center gap-1.5 text-sm text-ld-slate hover:text-ld-violet no-underline mb-6"
+        >
+          <ArrowLeft size={15} /> Kembali ke QA Library
+        </Link>
+
+        <h1 className="font-ld-display font-semibold text-2xl sm:text-3xl text-ld-onyx tracking-[-0.02em] leading-tight mb-4">
+          {article.title}
+        </h1>
+
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5 text-xs text-ld-fog mb-6">
+          <span className="inline-block px-2.5 py-1 rounded-md text-[11px] font-semibold uppercase tracking-widest bg-ld-lilac text-ld-violet">
+            {categoryLabel}
+          </span>
+          <span className="inline-flex items-center gap-1.5">
+            {article.authorAvatarUrl ? (
+              <img src={article.authorAvatarUrl} alt="" className="w-5 h-5 rounded-full object-cover object-top border border-ld-frost" />
+            ) : (
+              <User size={13} />
+            )}
+            {article.authorName}
+          </span>
+          <span className="inline-flex items-center gap-1.5"><Clock size={13} /> {article.readingTimeMinutes} menit baca</span>
+          <span className="inline-flex items-center gap-1.5"><Eye size={13} /> {article.viewCount.toLocaleString('id-ID')} dilihat</span>
+          <span className="inline-flex items-center gap-1.5"><CalendarDays size={13} /> {formatUpdatedDate(article.updatedAt)}</span>
+        </div>
+
+        {article.thumbnailUrl && (
+          <img
+            src={article.thumbnailUrl}
+            alt={article.title}
+            className="w-full aspect-video object-cover object-top rounded-xl border border-ld-frost mb-8"
+          />
+        )}
+
+        <div className="text-ld-onyx text-sm sm:text-base leading-relaxed markdown-body prose max-w-none">
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{article.body}</ReactMarkdown>
+        </div>
+
+        {article.docUrl && (
+          <a
+            href={article.docUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-8 inline-flex items-center gap-2.5 px-4 py-3 rounded-lg border border-ld-frost bg-white hover:border-ld-violet no-underline transition-colors"
+          >
+            <Download size={16} className="text-ld-violet shrink-0" />
+            <span className="text-sm text-ld-onyx font-medium">
+              {article.docFilename ?? 'Unduh dokumen'}
+              {article.docSizeBytes ? <span className="text-ld-fog font-normal"> ({formatBytes(article.docSizeBytes)})</span> : null}
+            </span>
+          </a>
+        )}
+
+        {article.tags.length > 0 && (
+          <div className="flex flex-wrap gap-2 mt-8 pt-6 border-t border-ld-frost/60">
+            {article.tags.map((tag) => (
+              <span key={tag} className="px-2.5 py-1 rounded-md text-xs text-ld-slate bg-ld-cloud">#{tag}</span>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {moreFromAuthor.length > 0 && (
+        <div className="max-w-5xl mx-auto px-4 mt-12 pt-10 border-t border-ld-frost/60">
+          <h2 className="font-ld-display font-semibold text-xl text-ld-onyx mb-5">
+            Lainnya dari {article.authorName}
+          </h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+            {moreFromAuthor.map((related) => (
+              <QaLibraryArticleCard key={related.id} article={related} categoryLabel={categoryLabelFor(related.categoryId)} />
+            ))}
+          </div>
+        </div>
+      )}
+    </article>
+  );
+};
+
+export default QaLibraryArticleDetailPage;

--- a/src/features/qa-library/pages/QaLibraryIndexPage.tsx
+++ b/src/features/qa-library/pages/QaLibraryIndexPage.tsx
@@ -1,0 +1,73 @@
+import React, { useState } from 'react';
+import { useQaLibraryArticles } from '../hooks/useQaLibraryArticles';
+import { useQaLibraryCategories } from '../hooks/useQaLibraryCategories';
+import QaLibraryArticleCard from '../components/QaLibraryArticleCard';
+import QaLibraryCategoryFilter from '../components/QaLibraryCategoryFilter';
+import LoadingState from '../../../components/common/LoadingState';
+import { usePagination } from '../../../hooks/usePagination';
+import Pagination from '../../admin/components/shared/Pagination';
+
+const PAGE_SIZE = 12;
+
+const QaLibraryIndexPage: React.FC = () => {
+  const [activeCategoryId, setActiveCategoryId] = useState<string | undefined>(undefined);
+  // Fetched unfiltered — filtering happens client-side below so the category
+  // chips can be limited to categories that actually have a published
+  // article, not the full taxonomy.
+  const { articles, loading, error, retry } = useQaLibraryArticles();
+  const { categories } = useQaLibraryCategories();
+  const categoryLabel = (id: string) => categories.find((c) => c.id === id)?.label ?? id;
+
+  const categoryIdsWithArticles = new Set(articles.map((a) => a.categoryId));
+  const visibleCategories = categories.filter((c) => categoryIdsWithArticles.has(c.id));
+  const filteredArticles = activeCategoryId ? articles.filter((a) => a.categoryId === activeCategoryId) : articles;
+  const { page, setPage, totalPages, pageItems: displayedArticles } = usePagination(filteredArticles, PAGE_SIZE);
+
+  return (
+    <div className="font-ld-sans pb-16">
+      <div className="max-w-5xl mx-auto px-4 pt-24 md:pt-28 pb-8 text-center">
+        <h1 className="font-ld-display font-semibold text-3xl sm:text-4xl text-ld-onyx tracking-[-0.02em] mb-3">
+          QA Library
+        </h1>
+        <p className="text-ld-slate text-sm sm:text-base leading-relaxed max-w-2xl mx-auto">
+          Kumpulan artikel dan materi seputar manual testing, automation testing, dan API testing untuk QA Engineer.
+        </p>
+      </div>
+
+      <div className="max-w-5xl mx-auto px-4">
+        {visibleCategories.length > 0 && (
+          <div className="mb-8">
+            <QaLibraryCategoryFilter categories={visibleCategories} activeCategoryId={activeCategoryId} onChange={setActiveCategoryId} />
+          </div>
+        )}
+
+        {loading ? (
+          <LoadingState label="Memuat artikel…" className="min-h-[40vh]" />
+        ) : error ? (
+          <div className="text-center py-16">
+            <p className="text-sm text-ld-slate mb-4">{error}</p>
+            <button
+              onClick={retry}
+              className="px-5 py-2.5 rounded-lg bg-ld-violet text-white text-sm font-medium cursor-pointer border-none hover:bg-[#1f87e6] transition-colors"
+            >
+              Coba lagi
+            </button>
+          </div>
+        ) : filteredArticles.length === 0 ? (
+          <p className="text-center text-sm text-ld-fog py-16">Belum ada artikel di category ini.</p>
+        ) : (
+          <>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+              {displayedArticles.map((article) => (
+                <QaLibraryArticleCard key={article.id} article={article} categoryLabel={categoryLabel(article.categoryId)} />
+              ))}
+            </div>
+            <Pagination page={page} totalPages={totalPages} totalItems={filteredArticles.length} pageSize={PAGE_SIZE} onPageChange={setPage} />
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default QaLibraryIndexPage;

--- a/src/index.css
+++ b/src/index.css
@@ -146,3 +146,98 @@ body {
     display: none;
   }
 }
+
+/* Spacing for react-markdown output (ProjectCard case studies, QA Library
+   articles). Tailwind's preflight zeroes p/heading/list margins and this
+   project doesn't have @tailwindcss/typography installed, so `prose` alone
+   is a no-op — these rules are what actually restore paragraph/heading
+   spacing wherever `.markdown-body` is used. */
+.markdown-body > :first-child {
+  margin-top: 0;
+}
+.markdown-body > :last-child {
+  margin-bottom: 0;
+}
+.markdown-body p {
+  margin: 0 0 1em;
+}
+.markdown-body h1,
+.markdown-body h2,
+.markdown-body h3,
+.markdown-body h4 {
+  margin: 1.6em 0 0.6em;
+  font-weight: 600;
+  line-height: 1.3;
+}
+.markdown-body h1 { font-size: 1.5em; }
+.markdown-body h2 { font-size: 1.3em; }
+.markdown-body h3 { font-size: 1.15em; }
+.markdown-body h4 { font-size: 1em; }
+.markdown-body ul,
+.markdown-body ol {
+  margin: 0 0 1em;
+  padding-left: 1.4em;
+}
+.markdown-body ul { list-style: disc; }
+.markdown-body ol { list-style: decimal; }
+.markdown-body li {
+  margin: 0.35em 0;
+}
+.markdown-body li > ul,
+.markdown-body li > ol {
+  margin: 0.35em 0 0.35em 0;
+}
+.markdown-body blockquote {
+  margin: 0 0 1em;
+  padding-left: 1em;
+  border-left: 3px solid currentColor;
+  opacity: 0.85;
+  font-style: italic;
+}
+.markdown-body hr {
+  margin: 1.6em 0;
+  border: none;
+  border-top: 1px solid currentColor;
+  opacity: 0.2;
+}
+.markdown-body table {
+  width: 100%;
+  margin: 0 0 1em;
+  border-collapse: collapse;
+  font-size: 0.92em;
+}
+.markdown-body th,
+.markdown-body td {
+  padding: 0.5em 0.75em;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  text-align: left;
+}
+.markdown-body th {
+  background: rgba(0, 0, 0, 0.04);
+  font-weight: 600;
+}
+.markdown-body del {
+  opacity: 0.6;
+}
+.markdown-body a {
+  color: var(--accent, #2590ff);
+  text-decoration: underline;
+}
+.markdown-body strong { font-weight: 600; }
+.markdown-body code {
+  padding: 0.15em 0.4em;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.06);
+  font-size: 0.9em;
+}
+.markdown-body pre {
+  margin: 0 0 1em;
+  padding: 0.9em 1em;
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.06);
+  overflow-x: auto;
+}
+.markdown-body pre code {
+  padding: 0;
+  background: none;
+}

--- a/src/lib/adminApi.ts
+++ b/src/lib/adminApi.ts
@@ -1,6 +1,7 @@
 // Thin fetch wrappers for the admin dashboard → /api endpoints.
 import type { BookingConfig, BookingRulesDocument, MentorConfig, TopicsDocument } from '../types/mentoring';
 import type { PortfolioData, PortfolioRecord, PortfolioStatus, PortfolioSummary, SkillsDocument, ToolsDocument } from '../types/portfolio';
+import type { QaLibraryArticle, QaLibraryArticleData, QaLibraryArticleSummary, QaLibraryCategoriesDocument } from '../types/qaLibrary';
 
 export class UnauthorizedError extends Error {
   constructor() {
@@ -353,7 +354,7 @@ export async function apiCheckSlug(slug: string, excludeId?: string): Promise<{ 
   return res.json();
 }
 
-export type UploadFeature = 'mentor' | 'portfolio' | 'cv' | 'tools';
+export type UploadFeature = 'mentor' | 'portfolio' | 'cv' | 'tools' | 'qaLibrary';
 
 export async function apiUploadImage(
   file: { filename: string; contentType: string; dataBase64: string; feature: UploadFeature },
@@ -371,4 +372,47 @@ export interface ArticleMetadata {
 
 export function apiFetchArticleMetadata(url: string, token: string): Promise<ArticleMetadata> {
   return apiPostAuth<ArticleMetadata>('/api/article-metadata', { url }, token);
+}
+
+export function apiGetQaLibraryCategories(): Promise<QaLibraryCategoriesDocument> {
+  return apiGet<QaLibraryCategoriesDocument>('/api/admin-config/qa-library-categories');
+}
+
+export function apiPutQaLibraryCategories(
+  doc: Pick<QaLibraryCategoriesDocument, 'categories'>,
+  updatedAt: string | undefined,
+  token: string
+): Promise<QaLibraryCategoriesDocument> {
+  return apiPut<QaLibraryCategoriesDocument>(
+    '/api/admin-config/qa-library-categories', doc, updatedAt, 'x-qa-library-categories-updated-at', token
+  );
+}
+
+export function apiListQaLibraryArticlesAdmin(token: string): Promise<{ articles: QaLibraryArticleSummary[] }> {
+  return apiGetAuth<{ articles: QaLibraryArticleSummary[] }>('/api/qa-library/admin', token);
+}
+
+export function apiGetQaLibraryArticle(slug: string, token: string): Promise<QaLibraryArticle> {
+  return apiGetAuth<QaLibraryArticle>(`/api/qa-library/${encodeURIComponent(slug)}`, token);
+}
+
+export type QaLibraryArticleWritePayload = QaLibraryArticleData & { slug: string };
+
+export function apiCreateQaLibraryArticle(payload: QaLibraryArticleWritePayload, token: string): Promise<QaLibraryArticle> {
+  return apiPostAuth<QaLibraryArticle>('/api/qa-library', payload, token);
+}
+
+export function apiUpdateQaLibraryArticle(
+  currentSlug: string,
+  payload: QaLibraryArticleWritePayload,
+  updatedAt: string,
+  token: string
+): Promise<QaLibraryArticle> {
+  return apiPut<QaLibraryArticle>(
+    `/api/qa-library/${encodeURIComponent(currentSlug)}`, payload, updatedAt, 'x-qa-library-article-updated-at', token
+  );
+}
+
+export function apiDeleteQaLibraryArticle(slug: string, token: string): Promise<void> {
+  return apiDeleteAuth(`/api/qa-library/${encodeURIComponent(slug)}`, token);
 }

--- a/src/lib/qaLibraryValidation.ts
+++ b/src/lib/qaLibraryValidation.ts
@@ -1,0 +1,110 @@
+// Structural validators for the QA Library (articles) feature — categories
+// and article records. Used by both the admin dashboard (client-side
+// pre-save check) and the /api/admin-config/qa-library-categories,
+// /api/qa-library serverless functions (server-side write validation).
+// Keep this file free of browser-only imports — it is bundled into the API.
+
+import type { QaLibraryArticleData, QaLibraryArticleStatus, QaLibraryCategory } from '../types/qaLibrary.js';
+import { isValidSlug } from './portfolioValidation.js';
+
+const ARTICLE_STATUSES: readonly QaLibraryArticleStatus[] = ['draft', 'published'];
+const WORDS_PER_MINUTE = 200;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+export type QaLibraryCategoriesValidationResult =
+  | { ok: true; categories: QaLibraryCategory[] }
+  | { ok: false; errors: string[] };
+
+export function validateQaLibraryCategories(data: unknown): QaLibraryCategoriesValidationResult {
+  const errors: string[] = [];
+
+  if (!isRecord(data)) return { ok: false, errors: ['Body harus berupa objek JSON.'] };
+
+  const ids = new Set<string>();
+  if (!Array.isArray(data.categories)) {
+    errors.push('categories: wajib array.');
+  } else {
+    data.categories.forEach((category, i) => {
+      if (!isRecord(category)) {
+        errors.push(`categories[${i}]: harus objek.`);
+        return;
+      }
+      if (!isNonEmptyString(category.id)) {
+        errors.push(`categories[${i}].id: wajib string non-kosong.`);
+      } else if (!isValidSlug(category.id)) {
+        errors.push(`categories[${i}].id: harus slug lowercase (a-z, 0-9, tanda hubung).`);
+      } else if (ids.has(category.id)) {
+        errors.push(`categories[${i}].id: duplikat "${category.id}".`);
+      } else {
+        ids.add(category.id);
+      }
+      if (!isNonEmptyString(category.label)) errors.push(`categories[${i}].label: wajib string non-kosong.`);
+      if (category.description !== undefined && typeof category.description !== 'string') {
+        errors.push(`categories[${i}].description: harus string.`);
+      }
+    });
+  }
+
+  if (errors.length > 0) return { ok: false, errors };
+  return { ok: true, categories: data.categories as QaLibraryCategory[] };
+}
+
+// Word count / WORDS_PER_MINUTE, min 1 — server-authoritative (recomputed on
+// every write, ignoring any client-sent value), also reused client-side for
+// a live "~4 min read" preview label in the article form.
+export function computeReadingTimeMinutes(body: string): number {
+  const wordCount = body.trim().split(/\s+/).filter(Boolean).length;
+  return Math.max(1, Math.round(wordCount / WORDS_PER_MINUTE));
+}
+
+export type QaLibraryArticleValidationResult =
+  | { ok: true; article: QaLibraryArticleData }
+  | { ok: false; errors: string[] };
+
+export function validateQaLibraryArticleData(data: unknown, validCategoryIds: Set<string>): QaLibraryArticleValidationResult {
+  const errors: string[] = [];
+
+  if (!isRecord(data)) return { ok: false, errors: ['Body harus berupa objek JSON.'] };
+
+  if (!isNonEmptyString(data.title)) errors.push('title: wajib string non-kosong.');
+  if (!isNonEmptyString(data.categoryId) || !validCategoryIds.has(data.categoryId as string)) {
+    errors.push('categoryId: category id tidak ditemukan.');
+  }
+  if (!isNonEmptyString(data.excerpt)) errors.push('excerpt: wajib string non-kosong.');
+  if (!isNonEmptyString(data.body)) errors.push('body: wajib string non-kosong.');
+  if (data.thumbnailUrl !== undefined && typeof data.thumbnailUrl !== 'string') errors.push('thumbnailUrl: harus string.');
+  if (data.docUrl !== undefined && typeof data.docUrl !== 'string') errors.push('docUrl: harus string.');
+  if (data.docFilename !== undefined && typeof data.docFilename !== 'string') errors.push('docFilename: harus string.');
+  if (data.docSizeBytes !== undefined && (typeof data.docSizeBytes !== 'number' || data.docSizeBytes < 0)) {
+    errors.push('docSizeBytes: harus angka >= 0.');
+  }
+  if (!Array.isArray(data.tags) || data.tags.some((t) => typeof t !== 'string' || !t.trim())) {
+    errors.push('tags: harus array string non-kosong.');
+  }
+  if (!isNonEmptyString(data.authorName)) errors.push('authorName: wajib string non-kosong.');
+  if (data.authorUserId !== undefined && typeof data.authorUserId !== 'string') errors.push('authorUserId: harus string.');
+  if (data.authorAvatarUrl !== undefined && typeof data.authorAvatarUrl !== 'string') errors.push('authorAvatarUrl: harus string.');
+  if (typeof data.status !== 'string' || !ARTICLE_STATUSES.includes(data.status as QaLibraryArticleStatus)) {
+    errors.push(`status: wajib salah satu dari ${ARTICLE_STATUSES.join(', ')}.`);
+  }
+  if (data.seoMetaTitle !== undefined && typeof data.seoMetaTitle !== 'string') errors.push('seoMetaTitle: harus string.');
+  if (data.seoMetaDescription !== undefined && typeof data.seoMetaDescription !== 'string') errors.push('seoMetaDescription: harus string.');
+  if (data.seoOgImage !== undefined && typeof data.seoOgImage !== 'string') errors.push('seoOgImage: harus string.');
+
+  // Publish-time rule: a published article must have a thumbnail (public
+  // grid/detail pages assume one), checked here so both client pre-save and
+  // server write enforce it identically.
+  if (data.status === 'published' && !isNonEmptyString(data.thumbnailUrl)) {
+    errors.push('thumbnailUrl: wajib diisi saat status "published".');
+  }
+
+  if (errors.length > 0) return { ok: false, errors };
+  return { ok: true, article: data as unknown as QaLibraryArticleData };
+}

--- a/src/store/useAdminQaLibraryCategoriesStore.ts
+++ b/src/store/useAdminQaLibraryCategoriesStore.ts
@@ -1,0 +1,90 @@
+import { create } from 'zustand';
+import type { QaLibraryCategory } from '../types/qaLibrary';
+import { apiGetQaLibraryCategories, apiPutQaLibraryCategories, ConflictError, UnauthorizedError } from '../lib/adminApi';
+import { validateQaLibraryCategories } from '../lib/qaLibraryValidation';
+import { useAdminAuthStore } from './useAdminAuthStore';
+import { dedupeInFlight, type InFlightHolder } from '../lib/dedupeInFlight';
+
+const deepCopy = <T,>(value: T): T => JSON.parse(JSON.stringify(value));
+
+export type ActionResult = { ok: boolean; reason?: string };
+
+interface AdminQaLibraryCategoriesState {
+  categories: QaLibraryCategory[];
+  categoriesUpdatedAt?: string;
+  loading: boolean;
+  loadError: string | null;
+
+  load: () => Promise<void>;
+  upsertCategory: (category: QaLibraryCategory) => Promise<ActionResult>;
+  deleteCategory: (categoryId: string) => Promise<ActionResult>;
+}
+
+// Same save-immediately-per-action pattern as tools/topics in
+// useAdminToolsStore.ts — categories is a small master lookup, whole-array
+// replace on every edit.
+async function commitCategories(
+  set: (partial: Partial<AdminQaLibraryCategoriesState>) => void,
+  get: () => AdminQaLibraryCategoriesState,
+  categories: QaLibraryCategory[]
+): Promise<ActionResult> {
+  const result = validateQaLibraryCategories({ categories });
+  if (!result.ok) return { ok: false, reason: result.errors.join(' ') };
+
+  const token = useAdminAuthStore.getState().token;
+  if (!token) {
+    useAdminAuthStore.getState().logout();
+    return { ok: false, reason: 'Sesi berakhir, silakan login ulang.' };
+  }
+
+  try {
+    const saved = await apiPutQaLibraryCategories({ categories: result.categories }, get().categoriesUpdatedAt, token);
+    set({ categories: deepCopy(saved.categories), categoriesUpdatedAt: saved.updatedAt });
+    return { ok: true };
+  } catch (err) {
+    if (err instanceof UnauthorizedError) {
+      useAdminAuthStore.getState().logout();
+      return { ok: false, reason: 'Sesi berakhir, silakan login ulang.' };
+    }
+    if (err instanceof ConflictError) {
+      const current = err.current as { categories: QaLibraryCategory[]; updatedAt: string };
+      set({ categories: deepCopy(current.categories), categoriesUpdatedAt: current.updatedAt });
+      return { ok: false, reason: 'Categories berubah di tempat lain. Data sudah dimuat ulang, coba lagi.' };
+    }
+    return { ok: false, reason: err instanceof Error ? err.message : 'Gagal menyimpan categories.' };
+  }
+}
+
+const loadRef: InFlightHolder<void> = { promise: null, rerun: false };
+
+export const useAdminQaLibraryCategoriesStore = create<AdminQaLibraryCategoriesState>((set, get) => ({
+  categories: [],
+  categoriesUpdatedAt: undefined,
+  loading: true,
+  loadError: null,
+
+  load: () => dedupeInFlight(loadRef, async () => {
+    set({ loading: true, loadError: null });
+    try {
+      const doc = await apiGetQaLibraryCategories();
+      set({ categories: deepCopy(doc.categories), categoriesUpdatedAt: doc.updatedAt });
+    } catch (err) {
+      set({ loadError: err instanceof Error ? err.message : 'Gagal memuat categories.' });
+    } finally {
+      set({ loading: false });
+    }
+  }),
+
+  upsertCategory: async (category) => {
+    const categories = deepCopy(get().categories);
+    const idx = categories.findIndex((c) => c.id === category.id);
+    if (idx >= 0) categories[idx] = category;
+    else categories.push(category);
+    return commitCategories(set, get, categories);
+  },
+
+  deleteCategory: async (categoryId) => {
+    const categories = get().categories;
+    return commitCategories(set, get, categories.filter((c) => c.id !== categoryId));
+  },
+}));

--- a/src/store/useAdminQaLibraryStore.ts
+++ b/src/store/useAdminQaLibraryStore.ts
@@ -1,0 +1,130 @@
+import { create } from 'zustand';
+import type { QaLibraryArticle, QaLibraryArticleSummary } from '../types/qaLibrary';
+import {
+  apiCreateQaLibraryArticle, apiDeleteQaLibraryArticle, apiGetQaLibraryArticle, apiListQaLibraryArticlesAdmin,
+  apiUpdateQaLibraryArticle, ApiError, ConflictError, type QaLibraryArticleWritePayload, UnauthorizedError,
+} from '../lib/adminApi';
+import { useAdminAuthStore } from './useAdminAuthStore';
+import { dedupeInFlight, type InFlightHolder } from '../lib/dedupeInFlight';
+
+export type ActionResult = { ok: boolean; reason?: string };
+
+// Real per-row resource, not a whole-array config document — mirrors
+// useAdminPortfolioStore.ts: the list only holds lightweight summaries, and
+// editing a single article fetches its full record (with body/doc fields)
+// on demand via loadOne().
+interface AdminQaLibraryState {
+  articles: QaLibraryArticleSummary[];
+  loading: boolean;
+  loadError: string | null;
+  load: () => Promise<void>;
+
+  current: QaLibraryArticle | null;
+  currentLoading: boolean;
+  currentError: string | null;
+  loadOne: (slug: string) => Promise<void>;
+  clearCurrent: () => void;
+
+  create: (payload: QaLibraryArticleWritePayload) => Promise<ActionResult>;
+  update: (currentSlug: string, payload: QaLibraryArticleWritePayload) => Promise<ActionResult>;
+  remove: (slug: string) => Promise<ActionResult>;
+}
+
+function requireToken(): string | null {
+  const token = useAdminAuthStore.getState().token;
+  if (!token) useAdminAuthStore.getState().logout();
+  return token;
+}
+
+const loadRef: InFlightHolder<void> = { promise: null, rerun: false };
+
+export const useAdminQaLibraryStore = create<AdminQaLibraryState>((set, get) => ({
+  articles: [],
+  loading: true,
+  loadError: null,
+
+  load: () => dedupeInFlight(loadRef, async () => {
+    const token = requireToken();
+    if (!token) return;
+    set({ loading: true, loadError: null });
+    try {
+      const { articles } = await apiListQaLibraryArticlesAdmin(token);
+      set({ articles });
+    } catch (err) {
+      if (err instanceof UnauthorizedError) return;
+      set({ loadError: err instanceof Error ? err.message : 'Gagal memuat artikel.' });
+    } finally {
+      set({ loading: false });
+    }
+  }),
+
+  current: null,
+  currentLoading: false,
+  currentError: null,
+
+  loadOne: async (slug) => {
+    const token = requireToken();
+    if (!token) return;
+    set({ currentLoading: true, currentError: null, current: null });
+    try {
+      const article = await apiGetQaLibraryArticle(slug, token);
+      set({ current: article });
+    } catch (err) {
+      if (err instanceof UnauthorizedError) return;
+      set({ currentError: err instanceof Error ? err.message : 'Gagal memuat artikel.' });
+    } finally {
+      set({ currentLoading: false });
+    }
+  },
+
+  clearCurrent: () => set({ current: null, currentError: null }),
+
+  create: async (payload) => {
+    const token = requireToken();
+    if (!token) return { ok: false, reason: 'Sesi berakhir, silakan login ulang.' };
+    try {
+      await apiCreateQaLibraryArticle(payload, token);
+      await get().load();
+      return { ok: true };
+    } catch (err) {
+      if (err instanceof UnauthorizedError) return { ok: false, reason: 'Sesi berakhir, silakan login ulang.' };
+      if (err instanceof ApiError && err.errors?.length) return { ok: false, reason: err.errors.join(' ') };
+      return { ok: false, reason: err instanceof Error ? err.message : 'Gagal membuat artikel.' };
+    }
+  },
+
+  update: async (currentSlug, payload) => {
+    const token = requireToken();
+    if (!token) return { ok: false, reason: 'Sesi berakhir, silakan login ulang.' };
+    const expectedUpdatedAt = get().current?.updatedAt;
+    if (!expectedUpdatedAt) return { ok: false, reason: 'Data artikel belum dimuat.' };
+    try {
+      const saved = await apiUpdateQaLibraryArticle(currentSlug, payload, expectedUpdatedAt, token);
+      set({ current: saved });
+      await get().load();
+      return { ok: true };
+    } catch (err) {
+      if (err instanceof UnauthorizedError) return { ok: false, reason: 'Sesi berakhir, silakan login ulang.' };
+      if (err instanceof ConflictError) {
+        const current = err.current as QaLibraryArticle;
+        set({ current });
+        return { ok: false, reason: 'Artikel ini berubah di tempat lain. Data sudah dimuat ulang, coba lagi.' };
+      }
+      if (err instanceof ApiError && err.errors?.length) return { ok: false, reason: err.errors.join(' ') };
+      return { ok: false, reason: err instanceof Error ? err.message : 'Gagal menyimpan artikel.' };
+    }
+  },
+
+  remove: async (slug) => {
+    const token = requireToken();
+    if (!token) return { ok: false, reason: 'Sesi berakhir, silakan login ulang.' };
+    try {
+      await apiDeleteQaLibraryArticle(slug, token);
+      await get().load();
+      return { ok: true };
+    } catch (err) {
+      if (err instanceof UnauthorizedError) return { ok: false, reason: 'Sesi berakhir, silakan login ulang.' };
+      return { ok: false, reason: err instanceof Error ? err.message : 'Gagal menghapus artikel.' };
+    }
+  },
+}));

--- a/src/types/qaLibrary.ts
+++ b/src/types/qaLibrary.ts
@@ -1,0 +1,57 @@
+// Canonical types for the QA Library (articles) feature.
+// Shared by the public /qa-library pages, the admin dashboard, and the /api functions.
+// Named QaLibrary* (not Article*) to avoid colliding with ArticleEntry in
+// src/types/portfolio.ts, an unrelated link-preview card type.
+
+export interface QaLibraryCategory {
+  id: string;
+  label: string;
+  description?: string;
+}
+
+export interface QaLibraryCategoriesDocument {
+  categories: QaLibraryCategory[];
+  updatedAt?: string;
+}
+
+export type QaLibraryArticleStatus = 'draft' | 'published';
+
+export interface QaLibraryArticleData {
+  title: string;
+  categoryId: string;
+  excerpt: string;
+  body: string; // markdown source
+  thumbnailUrl?: string;
+  docUrl?: string;
+  docFilename?: string;
+  docSizeBytes?: number;
+  tags: string[];
+  authorName: string;
+  // Optional ref/snapshot into the `users` table — set when the author is
+  // picked via the registered-user lookup in the admin form. authorName
+  // stays the source of truth for display (also covers authors who aren't
+  // registered users), authorUserId/authorAvatarUrl are a point-in-time
+  // snapshot taken at save time, not a live join.
+  authorUserId?: string;
+  authorAvatarUrl?: string;
+  status: QaLibraryArticleStatus;
+  seoMetaTitle?: string;
+  seoMetaDescription?: string;
+  seoOgImage?: string;
+}
+
+export interface QaLibraryArticle extends QaLibraryArticleData {
+  id: string;
+  slug: string;
+  readingTimeMinutes: number;
+  viewCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// Lightweight row for list views (admin table, public grid) — excludes body/doc metadata.
+export type QaLibraryArticleSummary = Pick<
+  QaLibraryArticle,
+  | 'id' | 'slug' | 'title' | 'categoryId' | 'excerpt' | 'thumbnailUrl' | 'tags' | 'status' | 'readingTimeMinutes'
+  | 'authorName' | 'authorAvatarUrl' | 'updatedAt'
+>;

--- a/vercel.json
+++ b/vercel.json
@@ -11,6 +11,17 @@
   "rewrites": [
     { "source": "/sitemap.xml", "destination": "/api/config?format=sitemap" },
     { "source": "/api/:path*", "destination": "/api/[...path]" },
+    {
+      "source": "/qa-library/:slug",
+      "has": [
+        {
+          "type": "header",
+          "key": "user-agent",
+          "value": ".*(facebookexternalhit|Facebot|WhatsApp|Twitterbot|Slackbot|LinkedInBot|TelegramBot|Discordbot|Pinterest|redditbot|SkypeUriPreview|vkShare|Applebot|Googlebot|bingbot|DuckDuckBot|YandexBot|Baiduspider).*"
+        }
+      ],
+      "destination": "/api/qa-library-og?slug=:slug"
+    },
     { "source": "/((?!api/|@|.*\\..*).*)", "destination": "/index.html" }
   ],
   "headers": [
@@ -23,7 +34,7 @@
         { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'sha256-Z2/iFzh9VMlVkEOar1f/oSHWwQk3ve1qk/C2WdsC4Xk=' https://accounts.google.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https:; connect-src 'self' https://accounts.google.com https://api.github.com; frame-src https://accounts.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'"
+          "value": "default-src 'self'; script-src 'self' 'sha256-Z2/iFzh9VMlVkEOar1f/oSHWwQk3ve1qk/C2WdsC4Xk=' https://accounts.google.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https:; connect-src 'self' https://accounts.google.com https://api.github.com https://vercel.com https://*.public.blob.vercel-storage.com; frame-src https://accounts.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'"
         }
       ]
     }


### PR DESCRIPTION
- Backend: Turso schema + storage layer for QA Library articles, category config document, admin-gated CRUD API, blob upload endpoint for thumbnails/docs, sitemap wiring
- Admin dashboard: new "Content" tab — Articles CRUD (markdown editor + preview, author select, category select, thumbnail/doc upload) and Article Categories management
- Public pages: /qa-library listing (category filter + pagination) and /qa-library/:slug detail page, "Lainnya dari [author]" related-articles section, QA Library nav link
- SEO: per-article canonical/OG/Twitter meta + Article JSON-LD, server-rendered OG preview for crawlers (WhatsApp/FB/Twitter/Google bots etc.) via bot-UA rewrite, since the SPA alone can't serve correct share previews to non-JS crawlers
- Fix: CSP connect-src widened for Vercel Blob upload domain (upload was silently broken without it)